### PR TITLE
Include descriptions for builtin objects

### DIFF
--- a/talondoc/__init__.py
+++ b/talondoc/__init__.py
@@ -4,6 +4,8 @@ import click
 
 from .autosummary.generate import generate
 
+from .preprocessing.builtin_extractor import extract_builtin
+
 __version__: str = "0.1.1"
 
 
@@ -108,6 +110,15 @@ def autogen(
         generate_conf=generate_conf,
         generate_index=generate_index,
     )
+
+
+@cli.command(name="preprocess")
+@click.argument(
+    "output_dir",
+    type=click.Path(),
+)
+def preprocess(output_dir: str):
+    extract_builtin(output_dir=output_dir)
 
 
 if __name__ == "__main__":

--- a/talondoc/__init__.py
+++ b/talondoc/__init__.py
@@ -4,7 +4,7 @@ import click
 
 from .autosummary.generate import generate
 
-from .preprocessing.builtin_extractor import extract_builtin
+from .cache_builtin.cache import cache_builtin
 
 __version__: str = "0.1.1"
 
@@ -112,13 +112,13 @@ def autogen(
     )
 
 
-@cli.command(name="preprocess")
+@cli.command(name="cache_builtin")
 @click.argument(
     "output_dir",
     type=click.Path(),
 )
 def preprocess(output_dir: str):
-    extract_builtin(output_dir=output_dir)
+    cache_builtin(output_dir=output_dir)
 
 
 if __name__ == "__main__":

--- a/talondoc/cache_builtin/cache.py
+++ b/talondoc/cache_builtin/cache.py
@@ -41,7 +41,7 @@ def send_to_repl(stdin: bytes) -> list[str]:
     return lines
 
 
-def extract_builtin(output_dir: Path = Path.cwd()):
+def cache_builtin(output_dir: Path = Path.cwd()):
     talon_version = send_to_repl(b"talon.app.version\n")[0].replace("'", "")
     lines = send_to_repl(b"actions.list()\n")
 
@@ -101,7 +101,7 @@ def extract_builtin(output_dir: Path = Path.cwd()):
             current_action = item.strip()
             current_description = []
 
-    output_path = Path.cwd() / ("talon_actions_dict" + talon_version + ".json")
+    output_path: Path = output_dir / ("talon_actions_dict" + talon_version + ".json")
     print(f"Writing built actions to {output_path}")
     with open(output_path, "w") as outfile:
         outfile.write(

--- a/talondoc/preprocessing/builtin_extractor.py
+++ b/talondoc/preprocessing/builtin_extractor.py
@@ -1,18 +1,38 @@
 import ast
+from dataclasses import asdict, dataclass
+from dataclasses_json import dataclass_json
 import json
 import subprocess
 from pathlib import Path
 
+from platform import system
+
+
+if system() == "Windows":
+    talon_repl_path: Path = (
+        Path.home() / "AppData\Roaming\\talon\.venv\Scripts\\repl.bat"
+    )
+else:
+    talon_repl_path: Path = Path.home() / ".talon\.venv\Scripts\\repl.bat"
+
+
+@dataclass_json
+@dataclass
+class Action:
+    name: str
+    description: str
+    returns: str
+    args: dict[str, str]
+
 
 def send_to_repl(stdin: bytes) -> list[str]:
-    talon_repl_path = Path.home() / "AppData\Roaming\\talon\.venv\Scripts\\repl.bat"
     proc = subprocess.Popen(
         [talon_repl_path],
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    print(proc.stdout.readline())
+    proc.stdout.readline()
 
     proc.stdin.write(stdin)
     proc.stdin.flush()
@@ -21,59 +41,74 @@ def send_to_repl(stdin: bytes) -> list[str]:
     return lines
 
 
-talon_version = send_to_repl(b"talon.app.version\n")[0].replace("'", "")
-lines = send_to_repl(b"actions.list()\n")
+def extract_builtin(output_dir: Path = Path.cwd()):
+    talon_version = send_to_repl(b"talon.app.version\n")[0].replace("'", "")
+    lines = send_to_repl(b"actions.list()\n")
+
+    action_dict = {}
+
+    current_action: str = ""
+    current_description: list[str] = []
+
+    for item in lines:
+        if item == "":
+            continue
+        elif item[0].isspace():
+            # Item is description
+            current_description.append(item.strip())
+        else:
+            # Add old action to grouped output
+            if current_action != "" and current_description:
+                # check if it is the initial action
+
+                # Remove the function defs
+                action_name = current_action.split("(")[0]
+
+                # Get the prefix to filter out user prefix
+                action_prefix = action_name.split(".")[0]
+
+                # auto_format didn't have a prefix so this is a work around of that issue
+                if len(current_action.split(".", 1)) == 2:
+                    action_base = current_action.split(".", 1)[1]
+                else:
+                    action_base = current_action.split(".", 1)[0]
+                if action_prefix != "user":
+                    args = {}
+
+                    function_def: ast.FunctionDef = ast.parse(
+                        "def " + action_base + ": ..."
+                    ).body[0]
+                    if function_def.args.args:
+                        for arg in function_def.args.args:
+                            if isinstance(arg.annotation, ast.Attribute):
+                                args[arg.arg] = ast.unparse(arg.annotation)
+                            elif isinstance(arg.annotation, ast.Name):
+                                args[arg.arg] = arg.annotation.id
+
+                    if isinstance(function_def.returns, ast.Name):
+                        returns = function_def.returns.id
+                    else:
+                        returns = ""
+
+                    action_dict[action_name] = Action(
+                        name=action_name,
+                        description=" ".join(current_description),
+                        args=args,
+                        returns=returns,
+                    )
+
+            # Item is the start of a new action
+            current_action = item.strip()
+            current_description = []
+
+    output_path = Path.cwd() / ("talon_actions_dict" + talon_version + ".json")
+    print(f"Writing built actions to {output_path}")
+    with open(output_path, "w") as outfile:
+        outfile.write(
+            json.dumps(
+                {key: asdict(value) for key, value in action_dict.items()}, indent=4
+            )
+        )
 
 
-action_dict = {}
-function_definitions = {}
-
-current_action: str = ""
-current_description: list[str] = []
-
-for item in lines:
-    if item == "":
-        continue
-    elif item[0].isspace():
-        # Item is description
-        current_description.append(item.strip())
-    else:
-        # Add old action to grouped output
-        if current_action != "" and current_description:
-            # check if it is the initial action
-
-            # Remove the function defs
-            action_name = current_action.split("(")[0]
-
-            # Get the prefix to filter out user prefix
-            action_prefix = action_name.split(".")[0]
-
-            # auto_format didn't have a prefix so this is a work around of that issue
-            if len(current_action.split(".", 1)) == 2:
-                action_base = current_action.split(".", 1)[1]
-            else:
-                action_base = current_action.split(".", 1)[0]
-            # action_base = current_action.replace(".", "\. ")
-            if action_prefix != "user":
-                action_dict[action_name.split("(")[0]] = " ".join(current_description)
-
-                function_def = "def " + action_base + ": ..."
-                function_definitions[action_name] = ast.parse(function_def)
-
-        # Item is the start of a new action
-        current_action = item.strip()
-        current_description = []
-
-
-# print()
-# print(processed_output)
-# print(function_definitions)
-# print(talon_version)
-
-output_path = Path.cwd() / ("talon_actions_dict" + talon_version + ".json")
-with open(output_path, "w") as outfile:
-    outfile.write(json.dumps(action_dict, indent=4))
-
-# output_path = Path.cwd() / ("talon_actions_signatures" + talon_version + ".json")
-# with open(output_path, "w") as outfile:
-#     outfile.write(json.dumps(function_definitions, indent=4))
+# extract_builtin()

--- a/talondoc/preprocessing/builtin_extractor.py
+++ b/talondoc/preprocessing/builtin_extractor.py
@@ -1,0 +1,79 @@
+import ast
+import json
+import subprocess
+from pathlib import Path
+
+
+def send_to_repl(stdin: bytes) -> list[str]:
+    talon_repl_path = Path.home() / "AppData\Roaming\\talon\.venv\Scripts\\repl.bat"
+    proc = subprocess.Popen(
+        [talon_repl_path],
+        stdout=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    print(proc.stdout.readline())
+
+    proc.stdin.write(stdin)
+    proc.stdin.flush()
+    lines: list[str] = proc.communicate()[0].decode().splitlines()
+
+    return lines
+
+
+talon_version = send_to_repl(b"talon.app.version\n")[0].replace("'", "")
+lines = send_to_repl(b"actions.list()\n")
+
+
+action_dict = {}
+function_definitions = {}
+
+current_action: str = ""
+current_description: list[str] = []
+
+for item in lines:
+    if item == "":
+        continue
+    elif item[0].isspace():
+        # Item is description
+        current_description.append(item.strip())
+    else:
+        # Add old action to grouped output
+        if current_action != "" and current_description:
+            # check if it is the initial action
+
+            # Remove the function defs
+            action_name = current_action.split("(")[0]
+
+            # Get the prefix to filter out user prefix
+            action_prefix = action_name.split(".")[0]
+
+            # auto_format didn't have a prefix so this is a work around of that issue
+            if len(current_action.split(".", 1)) == 2:
+                action_base = current_action.split(".", 1)[1]
+            else:
+                action_base = current_action.split(".", 1)[0]
+            # action_base = current_action.replace(".", "\. ")
+            if action_prefix != "user":
+                action_dict[action_name.split("(")[0]] = " ".join(current_description)
+
+                function_def = "def " + action_base + ": ..."
+                function_definitions[action_name] = ast.parse(function_def)
+
+        # Item is the start of a new action
+        current_action = item.strip()
+        current_description = []
+
+
+# print()
+# print(processed_output)
+# print(function_definitions)
+# print(talon_version)
+
+output_path = Path.cwd() / ("talon_actions_dict" + talon_version + ".json")
+with open(output_path, "w") as outfile:
+    outfile.write(json.dumps(action_dict, indent=4))
+
+# output_path = Path.cwd() / ("talon_actions_signatures" + talon_version + ".json")
+# with open(output_path, "w") as outfile:
+#     outfile.write(json.dumps(function_definitions, indent=4))


### PR DESCRIPTION
Fixes #4

I added the script in a new preprocessing folder. If that is not the best place for it then we can move it. I tried to put it in the util folder but got some python importing of a partially initialized library errors. Currently the script will export the dictionary of the actions and their descriptions to a json file that includes the current talon version b`talon_actions_dict0.3.1-17-geb94.json`. There is the functionality to also extract the python function signatures, but I am not sure on how best to export them at the moment 