### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/universal:2",
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/gh-cli:1": {},
+		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
+		"ghcr.io/devcontainers-contrib/features/wget-apt-get:1": {},
+		"ghcr.io/dhoeric/features/act:1": {},
+		"ghcr.io/devcontainers-contrib/features/tox": {},
+		"ghcr.io/devcontainers-contrib/features/poetry": {}
+	},
+	"postCreateCommand": "poetry install",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.makefile-tools",
+				"ms-python.python"
+			]
+		}
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 		"ghcr.io/devcontainers-contrib/features/tox": {},
 		"ghcr.io/devcontainers-contrib/features/poetry": {}
 	},
-	"postCreateCommand": "poetry install",
+	"postCreateCommand": "poetry install && git submodule init && git submodule update ",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,17 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/universal:2",
-	"features": {
-		"ghcr.io/devcontainers-contrib/features/gh-cli:1": {},
-		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
-		"ghcr.io/devcontainers-contrib/features/wget-apt-get:1": {},
-		"ghcr.io/dhoeric/features/act:1": {},
-		"ghcr.io/devcontainers-contrib/features/tox": {},
-		"ghcr.io/devcontainers-contrib/features/poetry": {}
-	},
-	"postCreateCommand": "poetry install && git submodule init && git submodule update && mypy --install-types  --non-interactive",
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"ms-vscode.makefile-tools",
-				"ms-python.python"
-			]
-		}
-	}
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/gh-cli:1": {},
+    "ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
+    "ghcr.io/devcontainers-contrib/features/wget-apt-get:1": {},
+    "ghcr.io/dhoeric/features/act:1": {},
+    "ghcr.io/devcontainers-contrib/features/tox": {},
+    "ghcr.io/devcontainers-contrib/features/poetry": {}
+  },
+  "postCreateCommand": "poetry install && git submodule init && git submodule update && mypy --install-types  --non-interactive",
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-vscode.makefile-tools", "ms-python.python"]
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 		"ghcr.io/devcontainers-contrib/features/tox": {},
 		"ghcr.io/devcontainers-contrib/features/poetry": {}
 	},
-	"postCreateCommand": "poetry install && git submodule init && git submodule update ",
+	"postCreateCommand": "poetry install && git submodule init && git submodule update && mypy --install-types  --non-interactive",
 	"customizations": {
 		"vscode": {
 			"extensions": [


### PR DESCRIPTION
Fixes #37

The dev container is based on the universal image that is used for GitHub codespaces. It also has several additional features added to it such as tox, gh-cli, pre\commit, act, and poetry. After it is created it will automatically install the project using poetry and then clone down the submodule.


I was running into an error when I ran make from mypy saying that it couldn't find docutils types and it suggested that to fix it needed this command to be run: 
```sh
mypy --install-types  
```
I went ahead and the dev container now also runs that command after setup. I have verified that from a clean rebuild of the container the base make command is working.
