### PR TITLE
Build binaries with PyInstaller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,15 +149,13 @@ jobs:
           ./bin/talondoc autogen example/docs -o knausj_talon --generate-index
           ./bin/talondoc build example/docs example/docs/_build
 
-      - if: runner.os == 'Linux' || runner.os == 'macOS'
-        run: |
-          mv ./bin/talondoc \
-             ./bin/talondoc-${{ matrix.os.type }}-${{ runner.arch }}
+      - name: Add target to binary name (Linux or macOS)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: mv ./bin/talondoc ./bin/talondoc-${{ matrix.os.type }}-${{ runner.arch }}
 
-      - if: runner.os == 'Windows'
-        run: |
-          mv ./bin/talondoc.exe \
-             ./bin/talondoc-${{ matrix.os.type }}-${{ runner.arch }}.exe
+      - name: Add target to binary name (Windows)
+        if: runner.os == 'Windows'
+        run: mv ./bin/talondoc.exe ./bin/talondoc-${{ matrix.os.type }}-${{ runner.arch }}.exe
 
       - name: Upload bin
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
 
       - name: Build
         run: ./scripts/pyinstaller.sh
+        shell: bash
 
       - name: Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,14 @@ jobs:
       - name: Build sdist
         run: pipx run --spec build pyproject-build --outdir dist
 
-      - name: Upload sdist
+      - name: Upload dist
         uses: actions/upload-artifact@v3
         with:
           name: dist
           path: |
             ./dist/*.tar.gz
             ./dist/*.whl
+          if-no-files-found: error
 
   ################################################################################
   # Test package with Tox
@@ -100,6 +101,71 @@ jobs:
 
       - name: Test
         run: pipx run tox
+
+  ################################################################################
+  # Build binaries with PyInstaller
+  ################################################################################
+
+  pyinstaller:
+    name: PyInstaller / ${{ matrix.os.name }}
+    runs-on: ${{ matrix.os.type }}
+    needs: [build, test]
+
+    strategy:
+      matrix:
+        os:
+          - name: "Linux"
+            type: "ubuntu-20.04"
+          - name: "macOS"
+            type: "macos-11"
+          - name: "Windows"
+            type: "windows-2022"
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Get source
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - # Required to run job via act: https://github.com/nektos/act
+        name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          cache: "pip"
+          cache-dependency-path: "./requirements-ci.txt"
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+
+      - # Required to run job via act: https://github.com/nektos/act
+        name: Setup dependencies
+        run: pip install -r "./requirements-ci.txt"
+
+      - name: Build
+        run: ./scripts/pyinstaller.sh
+
+      - name: Test
+        run: |
+          ./bin/talondoc autogen example/docs -o knausj_talon --generate-index
+          ./bin/talondoc build example/docs example/docs/_build
+
+      - if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: |
+          mv ./bin/talondoc \
+             ./bin/talondoc-${{ matrix.os.type }}-${{ runner.arch }}
+
+      - if: runner.os == 'Windows'
+        run: |
+          mv ./bin/talondoc.exe \
+             ./bin/talondoc-${{ matrix.os.type }}-${{ runner.arch }}.exe
+
+      - name: Upload bin
+        uses: actions/upload-artifact@v3
+        with:
+          name: bin
+          path: "./bin/talondoc-*"
+          if-no-files-found: error
 
   ################################################################################
   # Publish docs to GitHub Pages
@@ -152,6 +218,12 @@ jobs:
       contents: write
 
     steps:
+      - name: Download bin
+        uses: actions/download-artifact@v3
+        with:
+          name: bin
+          path: bin
+
       - name: Download dist
         uses: actions/download-artifact@v3
         with:
@@ -162,6 +234,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
+            bin/talondoc-*
             dist/*.tar.gz
             dist/*.whl
           fail_on_unmatched_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,6 @@ jobs:
   pyinstaller:
     name: PyInstaller / ${{ matrix.os.name }}
     runs-on: ${{ matrix.os.type }}
-    needs: [build, test]
 
     strategy:
       matrix:
@@ -212,7 +211,7 @@ jobs:
     name: Publish package to GitHub Releases
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build, test]
+    needs: [build, test, pyinstaller]
 
     permissions:
       contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # talondoc
 
+/bin/talondoc
+/bin/__main__.py
 /example/docs/_build
 /example/docs/knausj_talon
 

--- a/example/docs/conf.py
+++ b/example/docs/conf.py
@@ -9,8 +9,6 @@
 import os
 import sys
 
-from sphinx.application import Sphinx
-
 project = "TalonDoc"
 copyright = "2022, Wen Kokke"
 author = "Wen Kokke"
@@ -18,8 +16,6 @@ release = "1.0.0rc4"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
-
-sys.path.append(os.path.abspath("../.."))
 
 extensions = [
     # Enables support for Markdown
@@ -81,12 +77,17 @@ talon_package = {
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-
-# import sphinx_bootstrap_theme
-
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 html_css_files = [
     # Add a custom stylesheet for Sphinx Tabs
     "css/custom-tabs.css",
 ]
+
+# -- Setup function for PyInstaller  -----------------------------------------
+
+from sphinx.application import Sphinx
+
+def setup(app: Sphinx) -> None:
+    import sphinx_rtd_theme
+    sphinx_rtd_theme.setup(app)

--- a/scripts/pyinstaller.sh
+++ b/scripts/pyinstaller.sh
@@ -4,10 +4,10 @@
 ROOT_DIR="$(dirname "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit ; pwd -P )" )"
 
 # Create a virtual environment:
-python -m venv "${ROOT_DIR}/.venv"
+python -m venv "${ROOT_DIR}/_venv"
 
 # Activate the virtual environment:
-source "${ROOT_DIR}/.venv/bin/activate"
+source "${ROOT_DIR}/_venv/bin/activate"
 
 # Install TalonDoc
 pip install -q "${ROOT_DIR}"
@@ -33,4 +33,4 @@ pyinstaller                                                                     
   --collect-data "sphinx_rtd_theme" --collect-submodules "sphinx_rtd_theme" --hidden-import "sphinx_rtd_theme" \
   --collect-data "sphinx_tabs"      --collect-submodules "sphinx_tabs"      --hidden-import "sphinx_tabs"      \
   --onefile                                                                                                    \
-  "${ROOT_DIR}/.venv/bin/talondoc"
+  "${ROOT_DIR}/_venv/bin/talondoc"

--- a/scripts/pyinstaller.sh
+++ b/scripts/pyinstaller.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# See: https://stackoverflow.com/a/4774063
+ROOT_DIR="$(dirname "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit ; pwd -P )" )"
+
+# Create a virtual environment:
+python -m venv "${ROOT_DIR}/.venv"
+
+# Activate the virtual environment:
+source "${ROOT_DIR}/.venv/bin/activate"
+
+# Install TalonDoc
+pip install "${ROOT_DIR}"
+
+# Install PyInstaller
+pip install pyinstaller
+
+# Install hidden modules
+pip install myst_parser
+pip install sphinx_rtd_theme
+pip install sphinx_tabs
+
+# Compile TalonDoc with PyInstaller
+pyinstaller                                                                                                    \
+  --collect-data "tree_sitter_talon"                                                                           \
+  --collect-data "talondoc"                                                                                    \
+  --collect-data "myst_parser"      --collect-submodules "myst_parser"      --hidden-import "myst_parser"      \
+  --collect-data "sphinx_rtd_theme" --collect-submodules "sphinx_rtd_theme" --hidden-import "sphinx_rtd_theme" \
+  --collect-data "sphinx_tabs"      --collect-submodules "sphinx_tabs"      --hidden-import "sphinx_tabs"      \
+  --onefile                                                                                                    \
+  "${ROOT_DIR}/.venv/bin/talondoc"

--- a/scripts/pyinstaller.sh
+++ b/scripts/pyinstaller.sh
@@ -24,6 +24,8 @@ pip install sphinx_tabs
 pyinstaller                                                                                                    \
   --collect-data "tree_sitter_talon"                                                                           \
   --collect-data "talondoc"                                                                                    \
+  --collect-data "sphinx"                                                                                      \
+  --collect-data "sphinxcontrib"                                                                               \
   --collect-data "myst_parser"      --collect-submodules "myst_parser"      --hidden-import "myst_parser"      \
   --collect-data "sphinx_rtd_theme" --collect-submodules "sphinx_rtd_theme" --hidden-import "sphinx_rtd_theme" \
   --collect-data "sphinx_tabs"      --collect-submodules "sphinx_tabs"      --hidden-import "sphinx_tabs"      \

--- a/scripts/pyinstaller.sh
+++ b/scripts/pyinstaller.sh
@@ -3,12 +3,6 @@
 # See: https://stackoverflow.com/a/4774063
 ROOT_DIR="$(dirname "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit ; pwd -P )" )"
 
-# Create a virtual environment:
-python -m venv "${ROOT_DIR}/_venv"
-
-# Activate the virtual environment:
-source "${ROOT_DIR}/_venv/bin/activate"
-
 # Install TalonDoc
 pip install -q "${ROOT_DIR}"
 
@@ -20,9 +14,14 @@ pip install -q myst_parser
 pip install -q sphinx_rtd_theme
 pip install -q sphinx_tabs
 
+# Create main script:
+mkdir -p "${ROOT_DIR}/bin"
+echo 'import talondoc'     >  "${ROOT_DIR}/bin/__main__.py"
+echo 'talondoc.talondoc()' >> "${ROOT_DIR}/bin/__main__.py"
 
 # Compile TalonDoc with PyInstaller
 pyinstaller                                                                                                    \
+  --name "talondoc"                                                                                            \
   --distpath "bin"                                                                                             \
   --python-option "-X utf8"                                                                                    \
   --collect-data "tree_sitter_talon"                                                                           \
@@ -33,4 +32,4 @@ pyinstaller                                                                     
   --collect-data "sphinx_rtd_theme" --collect-submodules "sphinx_rtd_theme" --hidden-import "sphinx_rtd_theme" \
   --collect-data "sphinx_tabs"      --collect-submodules "sphinx_tabs"      --hidden-import "sphinx_tabs"      \
   --onefile                                                                                                    \
-  "${ROOT_DIR}/_venv/bin/talondoc"
+  "${ROOT_DIR}/bin/__main__.py"

--- a/scripts/pyinstaller.sh
+++ b/scripts/pyinstaller.sh
@@ -10,18 +10,21 @@ python -m venv "${ROOT_DIR}/.venv"
 source "${ROOT_DIR}/.venv/bin/activate"
 
 # Install TalonDoc
-pip install "${ROOT_DIR}"
+pip install -q "${ROOT_DIR}"
 
 # Install PyInstaller
-pip install pyinstaller
+pip install -q pyinstaller
 
 # Install hidden modules
-pip install myst_parser
-pip install sphinx_rtd_theme
-pip install sphinx_tabs
+pip install -q myst_parser
+pip install -q sphinx_rtd_theme
+pip install -q sphinx_tabs
+
 
 # Compile TalonDoc with PyInstaller
 pyinstaller                                                                                                    \
+  --distpath "bin"                                                                                             \
+  --python-option "-X utf8"                                                                                    \
   --collect-data "tree_sitter_talon"                                                                           \
   --collect-data "talondoc"                                                                                    \
   --collect-data "sphinx"                                                                                      \

--- a/src/talondoc/__init__.py
+++ b/src/talondoc/__init__.py
@@ -3,8 +3,9 @@ import os
 import socket
 import threading
 import webbrowser
-from http.server import HTTPServer, SimpleHTTPRequestHandler, ThreadingHTTPServer
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from sys import exit
 from typing import Any, Optional, Sequence
 
 import click

--- a/src/talondoc/_autogen/__init__.py
+++ b/src/talondoc/_autogen/__init__.py
@@ -3,7 +3,8 @@ import os
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Iterable, Iterator, Optional, Union
+from sys import exit
+from typing import Any, Optional, Union
 
 import jinja2
 import jinja2.sandbox

--- a/src/talondoc/analysis/live/__init__.py
+++ b/src/talondoc/analysis/live/__init__.py
@@ -7,6 +7,7 @@ import subprocess
 from collections.abc import Sequence
 from contextlib import AbstractContextManager
 from importlib.resources import Resource
+from sys import exit
 from types import TracebackType
 from typing import Optional
 


### PR DESCRIPTION
This is unfortunately not workable, because PyInstaller makes it impossible to pass `-X utf8` to Python, and forces Python to ignore environment variables, so the compiled executables wouldn't work on Windows.