### PR TITLE
 Update to use Community repo and drop python3.9

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "image": "mcr.microsoft.com/vscode/devcontainers/base",
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.9"
+      "version": "3.10"
     },
     "ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
     "ghcr.io/devcontainers-contrib/features/tox:2": {},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Build docs
         run: |
-          python -X utf8 -m talondoc autogen example/docs -o knausj_talon --generate-index
+          python -X utf8 -m talondoc autogen example/docs -o community --generate-index
           python -X utf8 -m talondoc build example/docs example/docs/_build
 
       - name: Setup Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
           cache: "pip"
           cache-dependency-path: "./requirements-ci.txt"
           python-version: |
-            3.9
             3.10
             3.11
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # talondoc
 
 /example/docs/_build
-/example/docs/knausj_talon
+/example/docs/community
 
 # Python
 

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,7 @@ cython_debug/
 ##  and can be added to the global gitignore or merged into this file.  For a more nuclear
 ##  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 ##.idea/
+
+
+# Vscode
+.vscode/settings.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "example/knausj_talon"]
-	path = example/knausj_talon
-	url = https://github.com/knausj85/knausj_talon.git
+[submodule "example/community"]
+	path = example/community
+	url = https://github.com/talonhub/community.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,4 @@ repos:
     hooks:
       - id: talonfmt
         args: ["--in-place", "--max-line-width=88"]
+        language_version: python3.10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.4.1"
+    rev: "v1.14.1"
     hooks:
       - id: mypy
         args: ["--config-file", "pyproject.toml"]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "debugpy",
+      "request": "launch",
+      "name": "Launch talondoc CLI",
+      "module": "talondoc",
+      "args": [
+        "--continue-on-error",
+        "autogen",
+        "${workspaceFolder}/example/docs",
+        "-o",
+        "community",
+        "--generate-index"
+      ]
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ docs: .venv/bin/activate
 
 .PHONY: autogen
 autogen: .venv/bin/activate
-	@bash -c "source .venv/bin/activate; pip install -q .[docs]; python -X utf8 -m talondoc autogen example/docs -o knausj_talon --generate-index"
+	@bash -c "source .venv/bin/activate; pip install -q .[docs]; python -X utf8 -m talondoc autogen example/docs -o community --generate-index"
 
 .venv/bin/activate:
 	@python -m venv .venv

--- a/example/docs/conf.py
+++ b/example/docs/conf.py
@@ -59,7 +59,7 @@ sphinx_tabs_disable_css_loading = True
 
 talon_package = {
     "name": "user",
-    "path": "../knausj_talon",
+    "path": "../community",
     "exclude": [
         "conftest.py",
         "test/stubs/talon/__init__.py",
@@ -83,6 +83,7 @@ talon_package = {
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
+
 
 def setup(app: Sphinx) -> None:
     # Add custom styles for Sphinx Tabs

--- a/example/docs/index.md
+++ b/example/docs/index.md
@@ -9,11 +9,11 @@ knausj_talon/index
 ## Loading a Talon package
 
 TalonDoc can analyse a Talon package or user directory. To load all Talon and
-Python files in `example/knausj_talon` we add the following to `conf.py`:
+Python files in `example/community` we add the following to `conf.py`:
 
 ```python
 talon_package = {
-  'path': '../knausj_talon',
+  'path': '../community',
   'name': 'user',
   'exclude': ['conftest.py', 'test/**'],
   'trigger': 'ready'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,10 @@
     "License :: OSI Approved :: MIT License",
     "Topic :: Software Development :: Compilers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
   ]
-  requires-python = ">=3.9,<3.12"
+  requires-python = ">=3.10,<3.12"
   dependencies = [
     "awesome_progress_bar >=1.7,<2",
     "docstring_parser >=0.14,<0.16",
@@ -80,7 +79,7 @@
   line_length = 88
 
 [tool.mypy]
-  python_version         = 3.9
+  python_version         = "3.10"
   strict                 = true
   ignore_missing_imports = true
   implicit_reexport      = false
@@ -100,6 +99,8 @@
   where = ["src"]
 
 [tool.tox]
+
+
   legacy_tox_ini = """
 [tox]
 envlist = py{39,310,311}-{rst,md}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,107 +1,105 @@
 [build-system]
-  requires      = ["setuptools>=45"]
-  build-backend = "setuptools.build_meta"
+requires = ["setuptools>=45"]
+build-backend = "setuptools.build_meta"
 
 [project]
-  name = "talondoc"
-  version = "1.0.0"
-  description = "A Sphinx extension for Talon user directories."
-  license = { file = 'LICENSE' }
-  authors = [
-    { name = "Wen Kokke", email = "wenkokke@users.noreply.github.com" },
-  ]
-  readme = "README.md"
-  keywords = ["talon", "sphinx"]
-  classifiers = [
-    "License :: OSI Approved :: MIT License",
-    "Topic :: Software Development :: Compilers",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-  ]
-  requires-python = ">=3.10,<3.12"
-  dependencies = [
-    "awesome_progress_bar >=1.7,<2",
-    "docstring_parser >=0.14,<0.16",
-    "editdistance >=0.6,<0.7",
-    "Jinja2 >=3,<4",
-    "Sphinx >=5,<8",
-    "talonfmt >=1.7.4,<2",
-    "tree_sitter_talon >=3!1.0,<3!2",
-    "colorlog >=6.7,<7",
-    "packaging >=23.1,<24",
-    'pywin32; platform_system=="Windows"',
-    "singledispatchmethod >=1.0,<2; python_version <'3.8'",
-  ]
+name = "talondoc"
+version = "1.0.0"
+description = "A Sphinx extension for Talon user directories."
+license = { file = 'LICENSE' }
+authors = [{ name = "Wen Kokke", email = "wenkokke@users.noreply.github.com" }]
+readme = "README.md"
+keywords = ["talon", "sphinx"]
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Topic :: Software Development :: Compilers",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+]
+requires-python = ">=3.10,<3.12"
+dependencies = [
+  "awesome_progress_bar >=1.7,<2",
+  "docstring_parser >=0.14,<0.16",
+  "editdistance >=0.6,<0.7",
+  "Jinja2 >=3,<4",
+  "Sphinx >=5,<8",
+  "talonfmt >=1.7.4,<2",
+  "tree_sitter_talon >=3!1.0,<3!2",
+  "colorlog >=6.7,<7",
+  "packaging >=23.1,<24",
+  'pywin32; platform_system=="Windows"',
+  "singledispatchmethod >=1.0,<2; python_version <'3.8'",
+]
 
-  [project.optional-dependencies]
-    mypy = [
-      "types_click",
-      "types_docutils",
-      "types_editdistance",
-      "types_jinja2",
-      "types_pytz",
-      "types_setuptools",
-    ]
-    test = [
-      "bumpver",
-      "myst_parser >=1,<2",
-      "sphinx_rtd_theme >=1.2,<2",
-      "sphinx_tabs >=3.4,<5",
-    ]
-    docs = [
-      "myst_parser >=1,<2",
-      "sphinx_rtd_theme >=1.2,<2",
-      "sphinx_tabs >=3.4,<5",
-    ]
+[project.optional-dependencies]
+mypy = [
+  "types_click",
+  "types_docutils",
+  "types_editdistance",
+  "types_jinja2",
+  "types_pytz",
+  "types_setuptools",
+]
+test = [
+  "bumpver",
+  "myst_parser >=1,<2",
+  "sphinx_rtd_theme >=1.2,<2",
+  "sphinx_tabs >=3.4,<5",
+]
+docs = [
+  "myst_parser >=1,<2",
+  "sphinx_rtd_theme >=1.2,<2",
+  "sphinx_tabs >=3.4,<5",
+]
 
-  [project.scripts]
-    talondoc = "talondoc:talondoc"
+[project.scripts]
+talondoc = "talondoc:talondoc"
 
 [tool.bumpver]
-  current_version = "1.0.0"
-  version_pattern = "MAJOR.MINOR.PATCH[TAG]"
-  commit_message  = "Bump version {old_version} -> {new_version}"
-  commit          = true
-  tag             = true
-  push            = true
+current_version = "1.0.0"
+version_pattern = "MAJOR.MINOR.PATCH[TAG]"
+commit_message = "Bump version {old_version} -> {new_version}"
+commit = true
+tag = true
+push = true
 
-  [tool.bumpver.file_patterns]
-    "pyproject.toml" = [
-      '^current_version = "{version}"$',
-      '^version = "{pep440_version}"$',
-    ]
-    "example/docs/conf.py" = ['^release = "{pep440_version}"$']
-    "src/talondoc/_version.py" = ['^__version__: str = "{pep440_version}"$']
+[tool.bumpver.file_patterns]
+"pyproject.toml" = [
+  '^current_version = "{version}"$',
+  '^version = "{pep440_version}"$',
+]
+"example/docs/conf.py" = ['^release = "{pep440_version}"$']
+"src/talondoc/_version.py" = ['^__version__: str = "{pep440_version}"$']
 
 [tool.isort]
-  profile     = "black"
-  line_length = 88
+profile = "black"
+line_length = 88
 
 [tool.mypy]
-  python_version         = "3.10"
-  strict                 = true
-  ignore_missing_imports = true
-  implicit_reexport      = false
-  warn_unused_ignores    = false
+python_version = "3.10"
+strict = true
+ignore_missing_imports = true
+implicit_reexport = false
+warn_unused_ignores = false
 
-  [[tool.mypy.overrides]]
-    module            = "sphinx.application"
-    implicit_reexport = true
+[[tool.mypy.overrides]]
+module = "sphinx.application"
+implicit_reexport = true
 
 [tool.pytest.ini_options]
-  enable_assertion_pass_hook = true
-  filterwarnings             = ["ignore::DeprecationWarning:.*:"]
-  minversion                 = "6.0"
-  testpaths                  = ["tests"]
+enable_assertion_pass_hook = true
+filterwarnings = ["ignore::DeprecationWarning:.*:"]
+minversion = "6.0"
+testpaths = ["tests"]
 
 [tool.setuptools.packages.find]
-  where = ["src"]
+where = ["src"]
 
 [tool.tox]
 
 
-  legacy_tox_ini = """
+legacy_tox_ini = """
 [tox]
 envlist = py{310,311}-{rst,md}
 isolated_build = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,104 +1,106 @@
 [build-system]
-requires = ["setuptools>=45"]
-build-backend = "setuptools.build_meta"
+  requires      = ["setuptools>=45"]
+  build-backend = "setuptools.build_meta"
 
 [project]
-name = "talondoc"
-version = "1.0.0"
-description = "A Sphinx extension for Talon user directories."
-license = { file = 'LICENSE' }
-authors = [{ name = "Wen Kokke", email = "wenkokke@users.noreply.github.com" }]
-readme = "README.md"
-keywords = ["talon", "sphinx"]
-classifiers = [
-  "License :: OSI Approved :: MIT License",
-  "Topic :: Software Development :: Compilers",
-  "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-]
-requires-python = ">=3.9,<3.12"
-dependencies = [
-  "awesome_progress_bar >=1.7,<2",
-  "docstring_parser >=0.14,<0.16",
-  "editdistance >=0.6,<0.7",
-  "Jinja2 >=3,<4",
-  "Sphinx >=5,<8",
-  "talonfmt >=1.7.4,<2",
-  "tree_sitter_talon >=3!1.0,<3!2",
-  "colorlog >=6.7,<7",
-  "packaging >=23.1,<24",
-  'pywin32; platform_system=="Windows"',
-  "singledispatchmethod >=1.0,<2; python_version <'3.8'",
-]
+  name = "talondoc"
+  version = "1.0.0"
+  description = "A Sphinx extension for Talon user directories."
+  license = { file = 'LICENSE' }
+  authors = [
+    { name = "Wen Kokke", email = "wenkokke@users.noreply.github.com" },
+  ]
+  readme = "README.md"
+  keywords = ["talon", "sphinx"]
+  classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Software Development :: Compilers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+  ]
+  requires-python = ">=3.9,<3.12"
+  dependencies = [
+    "awesome_progress_bar >=1.7,<2",
+    "docstring_parser >=0.14,<0.16",
+    "editdistance >=0.6,<0.7",
+    "Jinja2 >=3,<4",
+    "Sphinx >=5,<8",
+    "talonfmt >=1.7.4,<2",
+    "tree_sitter_talon >=3!1.0,<3!2",
+    "colorlog >=6.7,<7",
+    "packaging >=23.1,<24",
+    'pywin32; platform_system=="Windows"',
+    "singledispatchmethod >=1.0,<2; python_version <'3.8'",
+  ]
 
-[project.optional-dependencies]
-mypy = [
-  "types_click",
-  "types_docutils",
-  "types_editdistance",
-  "types_jinja2",
-  "types_pytz",
-  "types_setuptools",
-]
-test = [
-  "bumpver",
-  "myst_parser >=1,<2",
-  "sphinx_rtd_theme >=1.2,<2",
-  "sphinx_tabs >=3.4,<5"
-]
-docs = [
-  "myst_parser >=1,<2",
-  "sphinx_rtd_theme >=1.2,<2",
-  "sphinx_tabs >=3.4,<5"
-]
+  [project.optional-dependencies]
+    mypy = [
+      "types_click",
+      "types_docutils",
+      "types_editdistance",
+      "types_jinja2",
+      "types_pytz",
+      "types_setuptools",
+    ]
+    test = [
+      "bumpver",
+      "myst_parser >=1,<2",
+      "sphinx_rtd_theme >=1.2,<2",
+      "sphinx_tabs >=3.4,<5",
+    ]
+    docs = [
+      "myst_parser >=1,<2",
+      "sphinx_rtd_theme >=1.2,<2",
+      "sphinx_tabs >=3.4,<5",
+    ]
 
-[project.scripts]
-talondoc = "talondoc:talondoc"
+  [project.scripts]
+    talondoc = "talondoc:talondoc"
 
 [tool.bumpver]
-current_version = "1.0.0"
-version_pattern = "MAJOR.MINOR.PATCH[TAG]"
-commit_message = "Bump version {old_version} -> {new_version}"
-commit = true
-tag = true
-push = true
+  current_version = "1.0.0"
+  version_pattern = "MAJOR.MINOR.PATCH[TAG]"
+  commit_message  = "Bump version {old_version} -> {new_version}"
+  commit          = true
+  tag             = true
+  push            = true
 
-[tool.bumpver.file_patterns]
-"pyproject.toml" = [
-  '^current_version = "{version}"$',
-  '^version = "{pep440_version}"$',
-]
-"example/docs/conf.py" = ['^release = "{pep440_version}"$']
-"src/talondoc/_version.py" = ['^__version__: str = "{pep440_version}"$']
+  [tool.bumpver.file_patterns]
+    "pyproject.toml" = [
+      '^current_version = "{version}"$',
+      '^version = "{pep440_version}"$',
+    ]
+    "example/docs/conf.py" = ['^release = "{pep440_version}"$']
+    "src/talondoc/_version.py" = ['^__version__: str = "{pep440_version}"$']
 
 [tool.isort]
-profile = "black"
-line_length = 88
+  profile     = "black"
+  line_length = 88
 
 [tool.mypy]
-python_version = 3.9
-strict = true
-ignore_missing_imports = true
-implicit_reexport = false
-warn_unused_ignores = false
+  python_version         = 3.9
+  strict                 = true
+  ignore_missing_imports = true
+  implicit_reexport      = false
+  warn_unused_ignores    = false
 
-[[tool.mypy.overrides]]
-module = "sphinx.application"
-implicit_reexport = true
+  [[tool.mypy.overrides]]
+    module            = "sphinx.application"
+    implicit_reexport = true
 
 [tool.pytest.ini_options]
-enable_assertion_pass_hook = true
-filterwarnings = ["ignore::DeprecationWarning:.*:"]
-minversion = "6.0"
-testpaths = ["tests"]
+  enable_assertion_pass_hook = true
+  filterwarnings             = ["ignore::DeprecationWarning:.*:"]
+  minversion                 = "6.0"
+  testpaths                  = ["tests"]
 
 [tool.setuptools.packages.find]
-where = ["src"]
+  where = ["src"]
 
 [tool.tox]
-legacy_tox_ini = """
+  legacy_tox_ini = """
 [tox]
 envlist = py{39,310,311}-{rst,md}
 isolated_build = true
@@ -112,17 +114,17 @@ setenv =
   rst: TALONDOC_FORMAT = rst
   md: TALONDOC_FORMAT = md
 commands_pre =
-  cp -R '{tox_root}/example/knausj_talon' '{env_tmp_dir}/knausj_talon'
+  cp -R '{tox_root}/example/community' '{env_tmp_dir}/community'
   mkdir -p '{env_tmp_dir}/docs'
   cp '{tox_root}/example/docs/conf.py' '{env_tmp_dir}/docs/conf.py'
   cp '{tox_root}/example/docs/index.md' '{env_tmp_dir}/docs/index.md'
   cp -R '{tox_root}/example/docs/_static' '{env_tmp_dir}/docs/_static'
 commands =
   {envpython} -m bumpver update --patch --no-fetch --dry
-  {envpython} -X utf8 -m talondoc autogen '{env_tmp_dir}/docs' -o 'knausj_talon' --generate-index
+  {envpython} -X utf8 -m talondoc autogen '{env_tmp_dir}/docs' -o 'community' --generate-index
   {envpython} -X utf8 -m talondoc build '{env_tmp_dir}/docs' '{env_tmp_dir}/docs/_build'
 commands_post =
-  rm -rf '{env_tmp_dir}/knausj_talon'
+  rm -rf '{env_tmp_dir}/community'
   rm -f '{env_tmp_dir}/docs/conf.py'
   rm -f '{env_tmp_dir}/docs/index.md'
   rm -rf '{env_tmp_dir}/docs/_static'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@
 
   legacy_tox_ini = """
 [tox]
-envlist = py{39,310,311}-{rst,md}
+envlist = py{310,311}-{rst,md}
 isolated_build = true
 
 [testenv]

--- a/src/talondoc/_util/builtin.py
+++ b/src/talondoc/_util/builtin.py
@@ -1,10 +1,22 @@
+from typing import TypeGuard
+
 builtin_number_types: tuple[type, ...] = (
     int,
     float,
     complex,
 )
 
+
+def is_builtin_number_type(obj: object) -> TypeGuard[int | float | complex]:
+    return isinstance(obj, builtin_number_types)
+
+
 builtin_string_types: tuple[type, ...] = (str,)
+
+
+def is_builtin_string_type(obj: object) -> TypeGuard[str]:
+    return isinstance(obj, builtin_string_types)
+
 
 builtin_types: tuple[type, ...] = (
     *builtin_number_types,

--- a/src/talondoc/analysis/static/python/__init__.py
+++ b/src/talondoc/analysis/static/python/__init__.py
@@ -182,13 +182,19 @@ def analyse_files(
                 analyse_file(registry, file_path, package)
             except Exception as e:
                 if continue_on_error:
-                    raise e
-                else:
                     _LOGGER.exception(e)
+                else:
+                    raise e
 
         # Trigger callbacks:
         for event_code in trigger:
             callbacks = registry.lookup(data.Callback, event_code)
             if callbacks is not None:
                 for callback in callbacks:
-                    callback.function()
+                    try:
+                        callback.function()
+                    except Exception as e:
+                        if continue_on_error:
+                            _LOGGER.exception(e)
+                        else:
+                            raise e

--- a/src/talondoc/description/describer.py
+++ b/src/talondoc/description/describer.py
@@ -45,51 +45,6 @@ class TalonScriptDescriber:
         self.registry = registry
         self.docstring_hook = docstring_hook or (lambda clsname, name: None)
 
-    @singledispatchmethod
-    def describe(self, ast: Node) -> Optional[Description]:
-        raise TypeError(type(ast))
-
-    @describe.register
-    def _(self, ast: TalonCommandDeclaration) -> Optional[Description]:
-        return self.describe(ast.right)
-
-    @describe.register
-    def _(self, ast: TalonBlock) -> Optional[Description]:
-        buffer = []
-        for child in ast.children:
-            buffer.append(self.describe(child))
-        return concat(*buffer)
-
-    @describe.register
-    def _(self, ast: TalonExpressionStatement) -> Optional[Description]:
-        desc = self.describe(ast.expression)
-        if isinstance(ast.expression, TalonString):
-            return Step(desc=f'Insert "{desc}"')
-        return desc
-
-    @describe.register
-    def _(self, ast: TalonAssignmentStatement) -> Optional[Description]:
-        right = self.describe(ast.right)
-        return Step(f"Let <{ast.left.text}> be {right}")
-
-    @describe.register
-    def _(self, ast: TalonBinaryOperator) -> Optional[Description]:
-        left = self.describe(ast.left)
-        right = self.describe(ast.right)
-        return Value(f"{left} {ast.operator.text} {right}")
-
-    @describe.register
-    def _(self, ast: TalonVariable) -> Optional[Description]:
-        return Value(f"<{ast.text}>")
-
-    @describe.register
-    def _(self, ast: TalonKeyAction) -> Optional[Description]:
-        return Step(f"Press {ast.arguments.text.strip()}.")
-
-    @describe.register
-    def _(self, ast: TalonSleepAction, **kwargs: Any) -> Optional[Description]:
-        return None
-
     def get_docstring(
         self,
         cls: type[Data],
@@ -101,52 +56,60 @@ class TalonScriptDescriber:
         docstring = docstring or self.registry.lookup_description(cls, name)
         return docstring
 
-    @describe.register
-    def _(self, ast: TalonAction) -> Optional[Description]:
-        # TODO: resolve self.*
-        name = ast.action_name.text
-        docstring = self.get_docstring(data.Action, name)
-        if docstring:
-            desc = from_docstring(docstring)
-            if isinstance(desc, StepsTemplate):
-                desc = desc(
-                    tuple(
-                        self.describe(arg)
-                        for arg in ast.arguments.children
-                        if isinstance(arg, TalonExpression)
-                    )
+    def describe(self, ast: Node) -> Optional[Description]:
+        match ast:
+            case TalonSleepAction() | TalonComment():
+                return None
+
+            case (
+                TalonFloat()
+                | TalonInteger()
+                | TalonImplicitString()
+                | TalonStringContent()
+                | TalonStringEscapeSequence()
+                | TalonStringContent()
+            ):
+                return Value(ast.text)
+
+            #  Nodes that use format strings
+            case TalonBinaryOperator():
+                return Value(
+                    f"{self.describe(ast.left)} {ast.operator.text} {self.describe(ast.right)}"
                 )
-            return desc
-        return None
+            case TalonExpressionStatement() if isinstance(ast.expression, TalonString):
+                return Step(desc=f'Insert "{self.describe(ast.expression)}"')
+            case TalonAssignmentStatement():
+                return Step(f"Let <{ast.left.text}> be {self.describe(ast.right)}")
+            case TalonVariable():
+                return Value(f"<{ast.text}>")
+            case TalonKeyAction():
+                # Todo: maybe add way to render keypress
+                return Step(f"Press {ast.arguments.text.strip()}.")
 
-    @describe.register
-    def _(self, ast: TalonParenthesizedExpression) -> Optional[Description]:
-        return self.describe(ast.get_child())
+            # Nodes with Children
+            case TalonExpressionStatement():
+                return self.describe(ast.expression)
+            case TalonCommandDeclaration():
+                return self.describe(ast.right)
+            case TalonParenthesizedExpression():
+                return self.describe(ast.get_child())
+            case TalonBlock() | TalonString():
+                return concat(*(self.describe(child) for child in ast.children))
 
-    @describe.register
-    def _(self, ast: TalonComment) -> Optional[Description]:
-        return None
-
-    @describe.register
-    def _(self, ast: TalonInteger) -> Optional[Description]:
-        return Value(ast.text)
-
-    @describe.register
-    def _(self, ast: TalonFloat) -> Optional[Description]:
-        return Value(ast.text)
-
-    @describe.register
-    def _(self, ast: TalonImplicitString) -> Optional[Description]:
-        return Value(ast.text)
-
-    @describe.register
-    def _(self, ast: TalonString) -> Optional[Description]:
-        return concat(*(self.describe(child) for child in ast.children))
-
-    @describe.register
-    def _(self, ast: TalonStringContent) -> Optional[Description]:
-        return Value(ast.text)
-
-    @describe.register
-    def _(self, ast: TalonStringEscapeSequence) -> Optional[Description]:
-        return Value(ast.text)
+            case TalonAction():
+                # TODO: resolve self.*
+                docstring = self.get_docstring(data.Action, name=ast.action_name.text)
+                if docstring:
+                    desc = from_docstring(docstring)
+                    if isinstance(desc, StepsTemplate):
+                        desc = desc(
+                            tuple(
+                                self.describe(arg)
+                                for arg in ast.arguments.children
+                                if isinstance(arg, TalonExpression)
+                            )
+                        )
+                    return desc
+                return None
+            case _:
+                raise TypeError(type(ast))

--- a/src/talondoc/sphinx/_util/addnodes/__init__.py
+++ b/src/talondoc/sphinx/_util/addnodes/__init__.py
@@ -11,6 +11,7 @@ from ...._util.builtin import (
     builtin_string_types,
     builtin_type_names,
     builtin_types,
+    is_builtin_string_type,
 )
 from ...._util.logging import getLogger
 from ....analysis.static.python.shims import ObjectShim
@@ -118,7 +119,7 @@ def desc_literal(value: Any, **attributes: AttributeValue) -> addnodes.desc_sig_
         return desc_sig_keyword(nodes.Text("None"), **attributes)
     elif isinstance(value, builtin_number_types):
         return desc_sig_literal_number(nodes.Text(repr(value)), **attributes)
-    elif isinstance(value, builtin_string_types):
+    elif is_builtin_string_type(value):
         if len(value) == 1:
             return desc_sig_literal_char(nodes.Text(repr(value)), **attributes)
         else:

--- a/src/talondoc/sphinx/_util/addnodes/fragtable.py
+++ b/src/talondoc/sphinx/_util/addnodes/fragtable.py
@@ -31,8 +31,8 @@ def depart_fragtable_html(self: HTML5Translator, node: fragtable) -> None:
 
 
 def visit_fragtable(self: SphinxTranslator, node: fragtable) -> None:
-    self.visit_table(node)
+    self.visit_table(node)  # type: ignore
 
 
 def depart_fragtable(self: SphinxTranslator, node: fragtable) -> None:
-    self.depart_table(node)
+    self.depart_table(node)  # type: ignore

--- a/src/talondoc/sphinx/directives/action.py
+++ b/src/talondoc/sphinx/directives/action.py
@@ -19,12 +19,12 @@ class TalonActionDirective(TalonDocObjectDescription):
     optional_arguments = 0
     final_argument_whitespace = False
 
-    @override
+    @override  # type: ignore[misc]
     def get_signatures(self) -> list[str]:
         assert len(self.arguments) == 1
         return [str(self.arguments[0]).strip()]
 
-    @override
+    @override  # type: ignore[misc]
     def handle_signature(self, sig: str, signode: addnodes.desc_signature) -> str:
         default = self.talon.registry.lookup_default(data.Action, sig)
         if default:

--- a/src/talondoc/sphinx/directives/capture.py
+++ b/src/talondoc/sphinx/directives/capture.py
@@ -27,12 +27,12 @@ class TalonCaptureDirective(TalonDocObjectDescription):
     optional_arguments = 0
     final_argument_whitespace = False
 
-    @override
+    @override  # type: ignore[misc]
     def get_signatures(self) -> list[str]:
         assert len(self.arguments) == 1
         return [str(self.arguments[0]).strip()]
 
-    @override
+    @override  # type: ignore[misc]
     def handle_signature(self, sig: str, signode: addnodes.desc_signature) -> str:
         default = self.talon.registry.lookup_default(data.Capture, sig)
         if default:

--- a/src/talondoc/sphinx/directives/command/__init__.py
+++ b/src/talondoc/sphinx/directives/command/__init__.py
@@ -1,4 +1,5 @@
 import sys
+from typing import ClassVar
 
 from sphinx import addnodes
 from sphinx.util.typing import OptionSpec
@@ -17,7 +18,7 @@ class TalonCommandDirective(TalonDocCommandDescription):
     has_content = True
     required_arguments = 1
     optional_arguments = sys.maxsize
-    option_spec: OptionSpec = {
+    option_spec: ClassVar[OptionSpec] = {  # type: ignore
         "context": optional_strlist,
         "contexts": optional_strlist,
         "always_include_script": flag,

--- a/src/talondoc/sphinx/directives/command/__init__.py
+++ b/src/talondoc/sphinx/directives/command/__init__.py
@@ -24,11 +24,11 @@ class TalonCommandDirective(TalonDocCommandDescription):
     }
     final_argument_whitespace = False
 
-    @override
+    @override  # type: ignore[misc]
     def get_signatures(self) -> list[str]:
         return [" ".join(self.arguments)]
 
-    @override
+    @override  # type: ignore[misc]
     def handle_signature(self, sig: str, signode: addnodes.desc_signature) -> str:
         try:
             command = self.find_command(sig, fullmatch=False, restrict_to=self.contexts)

--- a/src/talondoc/sphinx/directives/command/abc.py
+++ b/src/talondoc/sphinx/directives/command/abc.py
@@ -119,7 +119,7 @@ class TalonDocCommandDescription(TalonDocObjectDescription):
         Describe the script using the docstrings on the script, the docstrings on
         the actions, or finally by including it as a code block.
         """
-        buffer = []
+        buffer: list[nodes.Element] = []
 
         # 1. Use the Talon docstrings in the command script. Talon docstrings are comments which start with ###.
         desc = self._try_describe_script_with_script_docstrings(command)

--- a/src/talondoc/sphinx/directives/command/hlist.py
+++ b/src/talondoc/sphinx/directives/command/hlist.py
@@ -1,4 +1,5 @@
 import sys
+from typing import ClassVar
 
 from docutils import nodes
 from sphinx import addnodes
@@ -16,7 +17,8 @@ class TalonCommandHListDirective(TalonDocCommandListDescription):
     has_content = False
     required_arguments = 0
     optional_arguments = sys.maxsize
-    option_spec: OptionSpec = {
+
+    option_spec: ClassVar[OptionSpec] = {  # type: ignore
         "context": optional_strlist,
         "contexts": optional_strlist,
         "always_include_script": flag,

--- a/src/talondoc/sphinx/directives/command/table.py
+++ b/src/talondoc/sphinx/directives/command/table.py
@@ -1,4 +1,5 @@
 import sys
+from typing import ClassVar
 
 from docutils import nodes
 from sphinx.util.typing import OptionSpec
@@ -25,7 +26,7 @@ class TalonCommandTableDirective(TalonDocCommandListDescription):
     has_content = False
     required_arguments = 0
     optional_arguments = sys.maxsize
-    option_spec: OptionSpec = {
+    option_spec: ClassVar[OptionSpec] = {  # type: ignore
         "context": optional_strlist,
         "contexts": optional_strlist,
         "always_include_script": flag,

--- a/src/talondoc/sphinx/directives/list.py
+++ b/src/talondoc/sphinx/directives/list.py
@@ -36,12 +36,12 @@ class TalonListDirective(TalonDocObjectDescription):
     optional_arguments = 0
     final_argument_whitespace = False
 
-    @override
+    @override  # type: ignore[misc]
     def get_signatures(self) -> list[str]:
         assert len(self.arguments) == 1
         return [str(self.arguments[0]).strip()]
 
-    @override
+    @override  # type: ignore[misc]
     def handle_signature(self, sig: str, signode: addnodes.desc_signature) -> str:
         default = self.talon.registry.lookup_default(data.List, sig)
         if default:

--- a/src/talondoc/sphinx/directives/mode.py
+++ b/src/talondoc/sphinx/directives/mode.py
@@ -17,12 +17,12 @@ class TalonModeDirective(TalonDocObjectDescription):
     optional_arguments = 0
     final_argument_whitespace = False
 
-    @override
+    @override  # type: ignore[misc]
     def get_signatures(self) -> list[str]:
         assert len(self.arguments) == 1
         return [str(self.arguments[0]).strip()]
 
-    @override
+    @override  # type: ignore[misc]
     def handle_signature(self, sig: str, signode: addnodes.desc_signature) -> str:
         mode = self.talon.registry.lookup(data.Mode, sig)
         if mode:

--- a/src/talondoc/sphinx/directives/setting.py
+++ b/src/talondoc/sphinx/directives/setting.py
@@ -32,12 +32,12 @@ class TalonSettingDirective(TalonDocObjectDescription):
     optional_arguments = 0
     final_argument_whitespace = False
 
-    @override
+    @override  # type: ignore[misc]
     def get_signatures(self) -> list[str]:
         assert len(self.arguments) == 1
         return [str(self.arguments[0]).strip()]
 
-    @override
+    @override  # type: ignore[misc]
     def handle_signature(self, sig: str, signode: addnodes.desc_signature) -> str:
         default = self.talon.registry.lookup_default(data.Setting, sig)
         if default:

--- a/src/talondoc/sphinx/directives/tag.py
+++ b/src/talondoc/sphinx/directives/tag.py
@@ -19,11 +19,11 @@ class TalonTagDirective(TalonDocObjectDescription):
     final_argument_whitespace = False
 
     @override
-    def get_signatures(self) -> list[str]:
+    def get_signatures(self) -> list[str]:  # type: ignore[misc, name-defined]
         assert len(self.arguments) == 1
         return [str(self.arguments[0]).strip()]
 
-    @override
+    @override  # type: ignore[misc, name-defined]
     def handle_signature(self, sig: str, signode: addnodes.desc_signature) -> str:
         tag = self.talon.registry.lookup(data.Tag, sig)
         if tag:


### PR DESCRIPTION
This is an update that address #190 and #191 and a few small fixes for issues with mypy and handling errors when encountering errors when extracting info from python files.

Should we add support for newer versions of python as well? Currently it only supports 3.10 and 3.11. Should we add 3.12/3.13 as well? 