### PR TITLE
Switching linting and formatting to Ruff

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
   "postCreateCommand": {
     "git-submodules": "git submodule update --init",
     "pre-commit": "pre-commit install",
-    "pip": "pip install .[docs]",
+    "pip": "pip install .[docs,dev]",
     "mypy": "mypy --install-types --non-interactive"
   },
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
       "extensions": [
         "ms-python.python",
         "ms-python.vscode-pylance",
-        "ms-vscode.makefile-tools"
+        "ms-vscode.makefile-tools",
+        "charliermarsh.ruff"
       ]
     }
   }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,8 +33,9 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
+        args: ["--fix"]
       # Run the formatter.
-      # - id: ruff-format
+      - id: ruff-format
   - repo: https://github.com/ikamensh/flynt/
     rev: "1.0.1"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,19 +28,17 @@ repos:
     hooks:
       - id: prettier
         exclude: "^(tests/data/golden|src/talondoc/_cache_builtin/resources|)s"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.1
+    hooks:
+      # Run the linter.
+      - id: ruff
+      # Run the formatter.
+      # - id: ruff-format
   - repo: https://github.com/ikamensh/flynt/
     rev: "1.0.1"
     hooks:
       - id: flynt
-  - repo: https://github.com/pycqa/isort
-    rev: "5.13.2"
-    hooks:
-      - id: isort
-        args: ["--profile=black", "--filter-files", "--line-width=88"]
-  - repo: https://github.com/psf/black
-    rev: "24.10.0"
-    hooks:
-      - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.14.1"
     hooks:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["charliermarsh.ruff"]
+}

--- a/example/docs/conf.py
+++ b/example/docs/conf.py
@@ -6,8 +6,8 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-import os
 import sys
+from pathlib import Path
 
 from sphinx.application import Sphinx
 
@@ -19,7 +19,7 @@ release = "1.0.0"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-sys.path.append(os.path.abspath("../.."))
+sys.path.append(str(Path("../..").resolve()))
 
 extensions = [
     # Enables support for Markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ select = [
   "SIM",
   # flake8-pie (PIE)
   "PIE",
+  # flake8-pyi (PYI)
+  "PYI",
+
   # isort
   "I",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,14 @@ test = [
   "bumpver",
   "myst_parser >=1,<5",
   "sphinx_rtd_theme >=1.2,<4",
-  "sphinx_tabs >=3.4,<5"
+  "sphinx_tabs >=3.4,<5",
 ]
 docs = [
   "myst_parser >=1,<5",
   "sphinx_rtd_theme >=1.2,<4",
-  "sphinx_tabs >=3.4,<5"
+  "sphinx_tabs >=3.4,<5",
 ]
+dev = ["ruff>=0.9,<1"]
 
 [project.scripts]
 talondoc = "talondoc:talondoc"
@@ -72,9 +73,15 @@ push = true
 "example/docs/conf.py" = ['^release = "{pep440_version}"$']
 "src/talondoc/_version.py" = ['^__version__: str = "{pep440_version}"$']
 
-[tool.isort]
-profile = "black"
-line_length = 88
+[tool.ruff]
+# line-length = 88
+
+[tool.ruff.lint]
+# Add the `line-too-long` rule to the enforced rule set. By default, Ruff omits rules that
+# overlap with the use of a formatter, like Black, but we can override this behavior by
+# explicitly adding the rule.
+# extend-select = ["E501"]
+
 
 [tool.mypy]
 python_version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,11 +120,6 @@ ignore = [
   "W191",   # tab-indentation (W191)
 ]
 
-[tool.ruff.lint.per-file-ignores]
-"__init__.py" = [
-  "E402",
-] # Ignore `E402` (import violations) in all `__init__.py` files, and in selected subdirectories.
-
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ select = [
   "PIE", # flake8-pie (PIE)
   "PYI", # flake8-pyi (PYI)
   "RUF", # Ruff Specific Rules
+  "RET", # flake8-return (RET)
 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,13 +74,56 @@ push = true
 "src/talondoc/_version.py" = ['^__version__: str = "{pep440_version}"$']
 
 [tool.ruff]
-# line-length = 88
+line-length = 88
 
 [tool.ruff.lint]
 # Add the `line-too-long` rule to the enforced rule set. By default, Ruff omits rules that
 # overlap with the use of a formatter, like Black, but we can override this behavior by
 # explicitly adding the rule.
 # extend-select = ["E501"]
+
+select = [
+  # pycodestyle
+  "E",
+  # Pyflakes
+  "F",
+  # pyupgrade
+  "UP",
+  # flake8-bugbear
+  "B",
+  # flake8-simplify
+  "SIM",
+  # isort
+  "I",
+]
+
+ignore = [
+  # These are recommended to be disabled when using ruff format.
+
+  "W191",   # tab-indentation (W191)
+  "E111",   # indentation-with-invalid-multiple (E111)
+  "E114",   # indentation-with-invalid-multiple-comment (E114)
+  "E117",   # over-indented (E117)
+  "D206",   # docstring-tab-indentation (D206)
+  "D300",   # triple-single-quotes (D300)
+  "Q000",   # bad-quotes-inline-string (Q000)
+  "Q001",   # bad-quotes-multiline-string (Q001)
+  "Q002",   # bad-quotes-docstring (Q002)
+  "Q003",   # avoidable-escaped-quote (Q003)
+  "COM812", # missing-trailing-comma (COM812)
+  "COM819", # prohibited-trailing-comma (COM819)
+  "ISC002", # multi-line-implicit-string-concatenation (ISC002) if used without ISC001 and flake8-implicit-str-concat.allow-multiline = false
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = [
+  "E402",
+] # Ignore `E402` (import violations) in all `__init__.py` files, and in selected subdirectories.
+
+
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 45
 
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ push = true
 [tool.ruff]
 line-length = 88
 
+exclude = [".venv", ".tox", "example/community/*"]
+
 [tool.ruff.lint]
 # Add the `line-too-long` rule to the enforced rule set. By default, Ruff omits rules that
 # overlap with the use of a formatter, like Black, but we can override this behavior by
@@ -95,6 +97,11 @@ select = [
   "SIM",
   # isort
   "I",
+
+  "UP", # alert you when better syntax is available in your python version
+
+  # Ruff Specific Rules
+  "RUF",
 ]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,8 @@ select = [
 
   # flake8-simplify
   "SIM",
+  # flake8-pie (PIE)
+  "PIE",
   # isort
   "I",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,18 +93,26 @@ select = [
   "UP",
   # flake8-bugbear
   "B",
+
+  # flake8-comprehensions (C4)
+  "C4",
+
   # flake8-simplify
   "SIM",
   # isort
   "I",
 
-  "UP", # alert you when better syntax is available in your python version
 
   # Ruff Specific Rules
   "RUF",
+
+
+  # flake8-annotations
+  # "ANN", # enforce type hints
 ]
 
 ignore = [
+
   # These are recommended to be disabled when using ruff format.
 
   "W191",   # tab-indentation (W191)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ select = [
   "I",   # isort
 
   # Additional
+  "PTH", # flake8-use-pathlib
   "C4",  # flake8-comprehensions (C4)
   "PIE", # flake8-pie (PIE)
   "PYI", # flake8-pyi (PYI)
@@ -99,9 +100,10 @@ select = [
 ]
 
 ignore = [
+  # PTH (flake8-use-pathlib), allow use of open() instead of Path.open()
+  "PTH123", # builtin-open-pathlib (PTH123)
 
   # These are recommended to be disabled when using ruff format.
-
   "COM812", # missing-trailing-comma (COM812)
   "COM819", # prohibited-trailing-comma (COM819)
   "D206",   # docstring-tab-indentation (D206)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,7 @@ dependencies = [
   "Sphinx >=5,<9",
   "talonfmt >=1.7.4,<2",
   "tree_sitter_talon >=3!1.0,<3!2",
-  "colorlog >=6.7,<7",
-  "packaging >=23.1,<25",
   'pywin32; platform_system=="Windows"',
-  "singledispatchmethod >=1.0,<2; python_version <'3.8'",
 ]
 
 [project.optional-dependencies]
@@ -85,54 +82,39 @@ exclude = [".venv", ".tox", "example/community/*"]
 # extend-select = ["E501"]
 
 select = [
-  # pycodestyle
-  "E",
-  # Pyflakes
-  "F",
-  # pyupgrade
-  "UP",
-  # flake8-bugbear
-  "B",
+  # Recommended Initial
+  "E",   # pycodestyle
+  "F",   # Pyflakes
+  "UP",  # pyupgrade
+  "B",   # flake8-bugbear
+  "SIM", # flake8-simplify
+  "I",   # isort
 
-  # flake8-comprehensions (C4)
-  "C4",
+  # Additional
+  "C4",  # flake8-comprehensions (C4)
+  "PIE", # flake8-pie (PIE)
+  "PYI", # flake8-pyi (PYI)
+  "RUF", # Ruff Specific Rules
 
-  # flake8-simplify
-  "SIM",
-  # flake8-pie (PIE)
-  "PIE",
-  # flake8-pyi (PYI)
-  "PYI",
-
-  # isort
-  "I",
-
-
-  # Ruff Specific Rules
-  "RUF",
-
-
-  # flake8-annotations
-  # "ANN", # enforce type hints
 ]
 
 ignore = [
 
   # These are recommended to be disabled when using ruff format.
 
-  "W191",   # tab-indentation (W191)
+  "COM812", # missing-trailing-comma (COM812)
+  "COM819", # prohibited-trailing-comma (COM819)
+  "D206",   # docstring-tab-indentation (D206)
+  "D300",   # triple-single-quotes (D300)
   "E111",   # indentation-with-invalid-multiple (E111)
   "E114",   # indentation-with-invalid-multiple-comment (E114)
   "E117",   # over-indented (E117)
-  "D206",   # docstring-tab-indentation (D206)
-  "D300",   # triple-single-quotes (D300)
+  "ISC002", # multi-line-implicit-string-concatenation (ISC002) if used without ISC001 and flake8-implicit-str-concat.allow-multiline = false
   "Q000",   # bad-quotes-inline-string (Q000)
   "Q001",   # bad-quotes-multiline-string (Q001)
   "Q002",   # bad-quotes-docstring (Q002)
   "Q003",   # avoidable-escaped-quote (Q003)
-  "COM812", # missing-trailing-comma (COM812)
-  "COM819", # prohibited-trailing-comma (COM819)
-  "ISC002", # multi-line-implicit-string-concatenation (ISC002) if used without ISC001 and flake8-implicit-str-concat.allow-multiline = false
+  "W191",   # tab-indentation (W191)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/talondoc/__init__.py
+++ b/src/talondoc/__init__.py
@@ -3,12 +3,12 @@ import os
 import socket
 import threading
 import webbrowser
+from collections.abc import Sequence
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import Any, Literal
 
 import click
-from typing_extensions import Literal
 
 from ._autogen import autogen
 from ._cache_builtin import cache_builtin
@@ -39,7 +39,7 @@ def talondoc(
     ctx: click.Context,
     *,
     log_level: Literal["ERROR", "WARNING", "INFO", "DEBUG"],
-    continue_on_error: Optional[bool],
+    continue_on_error: bool | None,
 ) -> None:
     if ctx.obj is None:
         ctx.obj = {}
@@ -131,19 +131,19 @@ def _autogen(
     ctx: click.Context,
     config_dir: str,
     *,
-    output_dir: Optional[str],
-    package_dir: Optional[str],
-    package_name: Optional[str],
-    template_dir: Optional[str],
-    include: Optional[Sequence[str]],
-    exclude: Optional[Sequence[str]],
-    trigger: Optional[Sequence[str]],
-    project: Optional[str],
-    author: Optional[str],
-    release: Optional[str],
+    output_dir: str | None,
+    package_dir: str | None,
+    package_name: str | None,
+    template_dir: str | None,
+    include: Sequence[str] | None,
+    exclude: Sequence[str] | None,
+    trigger: Sequence[str] | None,
+    project: str | None,
+    author: str | None,
+    release: str | None,
     generate_conf: bool,
     generate_index: bool,
-    format: Optional[Literal["rst", "md"]],
+    format: Literal["rst", "md"] | None,
 ) -> None:
     continue_on_error = (
         hasattr(ctx, "obj")
@@ -198,7 +198,7 @@ def _build(
     ctx: click.Context,
     source_dir: str,
     output_dir: str,
-    config_dir: Optional[str],
+    config_dir: str | None,
     server: bool,
 ) -> None:
     import sphinx.cmd.build
@@ -227,7 +227,7 @@ def _build(
     # Check config_dir:
     conf_py = Path(config_dir) / "conf.py"
     if not conf_py.exists():
-        did_you_mean: Optional[str] = None
+        did_you_mean: str | None = None
         for dirpath, _dirnames, filenames in os.walk(str(source_dir)):
             if "conf.py" in filenames:
                 did_you_mean = dirpath
@@ -287,7 +287,10 @@ def _build(
 
             def finish_request(self, request: Any, client_address: Any) -> None:
                 self.RequestHandlerClass(  # type: ignore[call-arg]
-                    request, client_address, self, directory=output_dir  # type: ignore[arg-type]
+                    request,
+                    client_address,
+                    self,  # type: ignore[arg-type]
+                    directory=output_dir,  # type: ignore[arg-type]
                 )
 
         def _start_server() -> None:

--- a/src/talondoc/_autogen/__init__.py
+++ b/src/talondoc/_autogen/__init__.py
@@ -311,7 +311,7 @@ def autogen(
     ]
     for file in talon_files:
         # Create path/to/talon/file.{md,rst}:
-        bar.step(f" {str(file.location.path)}")
+        bar.step(f" {file.location.path!s}")
         output_relpath = file.location.path.with_suffix(f".{format}")
         output_path = output_dir / output_relpath
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -348,7 +348,7 @@ def autogen(
     ]
     for file in python_files:
         # Create path/to/python/file.py.{md,rst}:
-        bar.step(f" {str(file.location.path)}")
+        bar.step(f" {file.location.path!s}")
         output_relpath = file.location.path.with_suffix(f".py.{format}")
         output_path = output_dir / output_relpath
         output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/talondoc/_autogen/__init__.py
+++ b/src/talondoc/_autogen/__init__.py
@@ -3,11 +3,10 @@ import os
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Literal
 
 import jinja2
 import jinja2.sandbox
-from typing_extensions import Literal
 
 from talondoc.sphinx import _canonicalize_talon_package, _canonicalize_vararg
 from talondoc.sphinx.typing import TalonPackage
@@ -40,11 +39,11 @@ def _subsubsection(title: str) -> str:
     return _underline(title, line="^")
 
 
-def _default_package_name(package_name: Optional[str], package_dir: Path) -> str:
+def _default_package_name(package_name: str | None, package_dir: Path) -> str:
     return package_name or package_dir.parts[-1]
 
 
-def _default_author(author: Optional[str]) -> str:
+def _default_author(author: str | None) -> str:
     if author:
         return author
     try:
@@ -54,22 +53,22 @@ def _default_author(author: Optional[str]) -> str:
 
 
 def autogen(
-    config_dir: Union[str, Path],
+    config_dir: str | Path,
     *,
-    package_name: Optional[str] = None,
-    package_dir: Union[None, str, Path] = None,
-    output_dir: Union[None, str, Path] = None,
-    template_dir: Union[None, str, Path] = None,
-    include: Optional[Sequence[str]] = None,
-    exclude: Optional[Sequence[str]] = None,
-    trigger: Optional[Sequence[str]] = None,
-    project: Optional[str] = None,
-    author: Optional[str] = None,
-    release: Optional[str] = None,
+    package_name: str | None = None,
+    package_dir: None | str | Path = None,
+    output_dir: None | str | Path = None,
+    template_dir: None | str | Path = None,
+    include: Sequence[str] | None = None,
+    exclude: Sequence[str] | None = None,
+    trigger: Sequence[str] | None = None,
+    project: str | None = None,
+    author: str | None = None,
+    release: str | None = None,
     generate_conf: bool = False,
     generate_index: bool = False,
     continue_on_error: bool = True,
-    format: Optional[Literal["md", "rst"]] = None,
+    format: Literal["md", "rst"] | None = None,
 ) -> None:
     # Ensure config_dir is Path:
     if isinstance(config_dir, str):
@@ -89,10 +88,7 @@ def autogen(
             _LOGGER.error(e)
             exit(1)
 
-    if output_dir:
-        output_dir = config_dir / output_dir
-    else:
-        output_dir = config_dir
+    output_dir = config_dir / output_dir if output_dir else config_dir
 
     # Check for conf.py:
     conf_py = config_dir / "conf.py"
@@ -107,14 +103,15 @@ def autogen(
             _LOGGER.warning(e)
 
     # Get talon_package from conf.py:
-    talon_package: Optional[TalonPackage] = None
+    talon_package: TalonPackage | None = None
     if "talon_package" in sphinx_config:
         talon_package = _canonicalize_talon_package(sphinx_config["talon_package"])
         if talon_package is None:
             _LOGGER.warning(f"Could not read talon_package in {conf_py}.")
     if "talon_packages" in sphinx_config:
         _LOGGER.warning(
-            "The autogen command does not support reading the configuration 'talon_packages'."
+            "The autogen command does not support reading"
+            " the configuration 'talon_packages'."
         )
 
     # Resolve package directory:

--- a/src/talondoc/_autogen/__init__.py
+++ b/src/talondoc/_autogen/__init__.py
@@ -81,7 +81,7 @@ def autogen(
 
     if output_dir and output_dir.is_absolute():
         _LOGGER.warning(
-            f"The output directory should be relative to the configuration directory."
+            "The output directory should be relative to the configuration directory."
         )
         try:
             output_dir = output_dir.relative_to(config_dir)
@@ -114,7 +114,7 @@ def autogen(
             _LOGGER.warning(f"Could not read talon_package in {conf_py}.")
     if "talon_packages" in sphinx_config:
         _LOGGER.warning(
-            f"The autogen command does not support reading the configuration 'talon_packages'."
+            "The autogen command does not support reading the configuration 'talon_packages'."
         )
 
     # Resolve package directory:

--- a/src/talondoc/_cache_builtin/__init__.py
+++ b/src/talondoc/_cache_builtin/__init__.py
@@ -1,6 +1,6 @@
 import json
-import os
 from collections.abc import Mapping
+from pathlib import Path
 
 from .._util.logging import getLogger
 from ..analysis.live import TalonRepl
@@ -18,7 +18,7 @@ def cache_builtin(output_dir: str) -> None:
             for cls, objs in builtin.items():
                 if isinstance(objs, Mapping):
                     _LOGGER.info(f"Found {len(objs)} {cls.lower()}s")
-        output_path = os.path.join(output_dir, "talon.json")
+        output_path = Path(output_dir) / "talon.json"
         with open(output_path, "w") as f:
             json.dump(builtin, f)
         _LOGGER.info(f"Wrote {output_path}")

--- a/src/talondoc/_cache_builtin/__init__.py
+++ b/src/talondoc/_cache_builtin/__init__.py
@@ -12,13 +12,13 @@ def cache_builtin(output_dir: str) -> None:
     with TalonRepl() as repl:
         version = str(repl.version)
         _LOGGER.info(f"Found Talon {version}")
-        _LOGGER.info(f"Getting builtin declarations...")
+        _LOGGER.info("Getting builtin declarations...")
         builtin = repl.builtin_registry.to_dict()
         if isinstance(builtin, Mapping):
             for cls, objs in builtin.items():
                 if isinstance(objs, Mapping):
                     _LOGGER.info(f"Found {len(objs)} {cls.lower()}s")
-        output_path = os.path.join(output_dir, f"talon.json")
+        output_path = os.path.join(output_dir, "talon.json")
         with open(output_path, "w") as f:
             json.dump(builtin, f)
         _LOGGER.info(f"Wrote {output_path}")

--- a/src/talondoc/_util/io.py
+++ b/src/talondoc/_util/io.py
@@ -23,11 +23,10 @@ class NonBlockingTextIOWrapper:
     def readline(self, block: bool = False, timeout: float | None = None) -> str | None:
         if self._stream.closed and self._queue.qsize() == 0:
             return None
-        else:
-            try:
-                return self._queue.get(block=block, timeout=timeout)
-            except queue.Empty:
-                return None
+        try:
+            return self._queue.get(block=block, timeout=timeout)
+        except queue.Empty:
+            return None
 
     def readlines(
         self, block: bool = False, timeout: float | None = None

--- a/src/talondoc/_util/io.py
+++ b/src/talondoc/_util/io.py
@@ -2,7 +2,6 @@ import io
 import queue
 import threading
 from collections.abc import Callable, Iterator
-from typing import Optional
 
 
 class NonBlockingTextIOWrapper:
@@ -21,9 +20,7 @@ class NonBlockingTextIOWrapper:
             self._queue.put(line)
         self._stream.close()
 
-    def readline(
-        self, block: bool = False, timeout: Optional[float] = None
-    ) -> Optional[str]:
+    def readline(self, block: bool = False, timeout: float | None = None) -> str | None:
         if self._stream.closed and self._queue.qsize() == 0:
             return None
         else:
@@ -33,7 +30,7 @@ class NonBlockingTextIOWrapper:
                 return None
 
     def readlines(
-        self, block: bool = False, timeout: Optional[float] = None
+        self, block: bool = False, timeout: float | None = None
     ) -> Iterator[str]:
         while True:
             line = self.readline(block=block, timeout=timeout)
@@ -43,7 +40,7 @@ class NonBlockingTextIOWrapper:
                 yield line
 
     def readuntil(
-        self, predicate: Callable[[str], bool], timeout: Optional[float] = None
+        self, predicate: Callable[[str], bool], timeout: float | None = None
     ) -> Iterator[str]:
         yield from self.readwhile(
             predicate=lambda line: not predicate(line),
@@ -51,7 +48,7 @@ class NonBlockingTextIOWrapper:
         )
 
     def readwhile(
-        self, predicate: Callable[[str], bool], timeout: Optional[float] = None
+        self, predicate: Callable[[str], bool], timeout: float | None = None
     ) -> Iterator[str]:
         while True:
             line = self.readline(block=True, timeout=timeout)

--- a/src/talondoc/_util/logging.py
+++ b/src/talondoc/_util/logging.py
@@ -19,8 +19,7 @@ if "sphinx" not in sys.modules:
         def format(self, record: LogRecord) -> str:
             if record.levelno == INFO:
                 return record.getMessage()
-            else:
-                return super().format(record)  # type: ignore[no-any-return]
+            return super().format(record)  # type: ignore[no-any-return]
 
     _FORMATTER = PrettyColoredFormatter(
         fmt="%(log_color)s%(levelname)s: %(message)s",

--- a/src/talondoc/analysis/live/__init__.py
+++ b/src/talondoc/analysis/live/__init__.py
@@ -28,8 +28,7 @@ class TalonRepl(AbstractContextManager["TalonRepl"]):
     def executable_path(self) -> str:
         if platform.system() == "Windows":
             return os.path.expandvars("%APPDATA%\\talon\\.venv\\Scripts\\repl.bat")
-        else:
-            return os.path.expandvars("$HOME/.talon/.venv/bin/repl")
+        return os.path.expandvars("$HOME/.talon/.venv/bin/repl")
 
     def __enter__(self) -> Self:
         self.open()

--- a/src/talondoc/analysis/live/__init__.py
+++ b/src/talondoc/analysis/live/__init__.py
@@ -68,7 +68,10 @@ class TalonRepl(AbstractContextManager["TalonRepl"]):
     def eval(self, *line: str, encoding: str = "utf-8") -> str:
         assert self._session and self._session.stdin and self._session_stdout
         __EOR__ = "END_OF_RESPONSE"
-        is_EOR = lambda line: line == __EOR__
+
+        def is_EOR(line: str) -> bool:
+            return line == __EOR__
+
         print_EOR = f"print('{__EOR__}')"
         self._session.stdin.write(bytes("\n".join([*line, print_EOR]) + "\n", encoding))
         self._session.stdin.flush()
@@ -77,8 +80,8 @@ class TalonRepl(AbstractContextManager["TalonRepl"]):
     def eval_file(self, file: str, *, encoding: str = "utf-8") -> str:
         return self.eval(
             f"with open('{file}', 'r', encoding='{encoding}') as f:",
-            f"    exec(f.read())",
-            f"",
+            "    exec(f.read())",
+            "",
         )
 
     def eval_resource(self, resource: Resource, *, encoding: str = "utf-8") -> str:

--- a/src/talondoc/analysis/live/__init__.py
+++ b/src/talondoc/analysis/live/__init__.py
@@ -8,7 +8,6 @@ from collections.abc import Sequence
 from contextlib import AbstractContextManager
 from importlib.resources import Resource
 from types import TracebackType
-from typing import Optional
 
 from packaging.version import Version
 from typing_extensions import Self
@@ -21,9 +20,9 @@ _LOGGER = getLogger(__name__)
 
 
 class TalonRepl(AbstractContextManager["TalonRepl"]):
-    _session: Optional[subprocess.Popen[bytes]]
-    _session_stdout: Optional[NonBlockingTextIOWrapper]
-    _session_stderr: Optional[NonBlockingTextIOWrapper]
+    _session: subprocess.Popen[bytes] | None
+    _session_stdout: NonBlockingTextIOWrapper | None
+    _session_stderr: NonBlockingTextIOWrapper | None
 
     @property
     def executable_path(self) -> str:
@@ -97,9 +96,9 @@ class TalonRepl(AbstractContextManager["TalonRepl"]):
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         self.close()
 

--- a/src/talondoc/analysis/live/resources/get_actions.py
+++ b/src/talondoc/analysis/live/resources/get_actions.py
@@ -18,14 +18,14 @@ def _get_actions() -> None:
                 "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
             }
 
-    def asdict_class(cls: type) -> typing.Optional[str]:
+    def asdict_class(cls: type) -> str | None:
         if cls in (inspect.Signature.empty, inspect.Parameter.empty):
             return None
         if hasattr(cls, "__name__"):
             return cls.__name__
         return repr(cls)
 
-    def asdict_parameter(par: inspect.Parameter) -> typing.Dict[str, typing.Any]:
+    def asdict_parameter(par: inspect.Parameter) -> dict[str, typing.Any]:
         return {
             "name": par.name,
             "kind": par.kind,
@@ -33,7 +33,7 @@ def _get_actions() -> None:
             "annotation": asdict_class(par.annotation),
         }
 
-    def asdict_signature(sig: inspect.Signature) -> typing.Dict[str, typing.Any]:
+    def asdict_signature(sig: inspect.Signature) -> dict[str, typing.Any]:
         return {
             "parameters": [asdict_parameter(par) for par in sig.parameters.values()],
             "return_annotation": asdict_class(sig.return_annotation),

--- a/src/talondoc/analysis/live/resources/get_actions.py
+++ b/src/talondoc/analysis/live/resources/get_actions.py
@@ -13,10 +13,9 @@ def _get_actions() -> None:
     def asdict_pickle(value: typing.Any) -> typing.Any:
         if isinstance(value, str):
             return value
-        else:
-            return {
-                "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
-            }
+        return {
+            "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
+        }
 
     def asdict_class(cls: type) -> str | None:
         if cls in (inspect.Signature.empty, inspect.Parameter.empty):

--- a/src/talondoc/analysis/live/resources/get_captures.py
+++ b/src/talondoc/analysis/live/resources/get_captures.py
@@ -13,10 +13,9 @@ def _get_captures() -> None:
     def asdict_pickle(value: typing.Any) -> typing.Any:
         if isinstance(value, str):
             return value
-        else:
-            return {
-                "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
-            }
+        return {
+            "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
+        }
 
     def asdict_class(cls: type) -> str | None:
         if cls in (inspect.Signature.empty, inspect.Parameter.empty):

--- a/src/talondoc/analysis/live/resources/get_captures.py
+++ b/src/talondoc/analysis/live/resources/get_captures.py
@@ -18,14 +18,14 @@ def _get_captures() -> None:
                 "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
             }
 
-    def asdict_class(cls: type) -> typing.Optional[str]:
+    def asdict_class(cls: type) -> str | None:
         if cls in (inspect.Signature.empty, inspect.Parameter.empty):
             return None
         if hasattr(cls, "__name__"):
             return cls.__name__
         return repr(cls)
 
-    def asdict_parameter(par: inspect.Parameter) -> typing.Dict[str, typing.Any]:
+    def asdict_parameter(par: inspect.Parameter) -> dict[str, typing.Any]:
         return {
             "name": par.name,
             "kind": par.kind,
@@ -33,7 +33,7 @@ def _get_captures() -> None:
             "annotation": asdict_class(par.annotation),
         }
 
-    def asdict_signature(sig: inspect.Signature) -> typing.Dict[str, typing.Any]:
+    def asdict_signature(sig: inspect.Signature) -> dict[str, typing.Any]:
         return {
             "parameters": [asdict_parameter(par) for par in sig.parameters.values()],
             "return_annotation": asdict_class(sig.return_annotation),

--- a/src/talondoc/analysis/live/resources/get_lists.py
+++ b/src/talondoc/analysis/live/resources/get_lists.py
@@ -10,10 +10,9 @@ def _get_lists() -> None:
     def asdict_pickle(value: typing.Any) -> typing.Any:
         if isinstance(value, str):
             return value
-        else:
-            return {
-                "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
-            }
+        return {
+            "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
+        }
 
     def asdict_list_value(value: typing.Mapping[typing.Any, typing.Any]) -> typing.Any:
         return {key: asdict_pickle(val) for key, val in value.items()}

--- a/src/talondoc/analysis/live/resources/get_settings.py
+++ b/src/talondoc/analysis/live/resources/get_settings.py
@@ -10,10 +10,9 @@ def _get_settings() -> None:
     def asdict_pickle(value: typing.Any) -> typing.Any:
         if isinstance(value, str):
             return value
-        else:
-            return {
-                "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
-            }
+        return {
+            "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
+        }
 
     def asdict_class(cls: type) -> str | None:
         if hasattr(cls, "__name__"):

--- a/src/talondoc/analysis/live/resources/get_settings.py
+++ b/src/talondoc/analysis/live/resources/get_settings.py
@@ -15,7 +15,7 @@ def _get_settings() -> None:
                 "pickle": base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
             }
 
-    def asdict_class(cls: type) -> typing.Optional[str]:
+    def asdict_class(cls: type) -> str | None:
         if hasattr(cls, "__name__"):
             return cls.__name__
         return repr(cls)

--- a/src/talondoc/analysis/registry/__init__.py
+++ b/src/talondoc/analysis/registry/__init__.py
@@ -85,7 +85,7 @@ class Registry:
         _LOGGER.debug(
             " ".join(
                 [
-                    f"Found",
+                    "Found",
                     (
                         "declaration"
                         if issubclass(value.parent_type, data.Module)
@@ -278,7 +278,7 @@ class Registry:
                     value = cast(DataVar, obj)
                     break
         elif issubclass(cls, data.Callback):
-            raise NotImplementedError(f"Registry.get does not support callbacks")
+            raise NotImplementedError("Registry.get does not support callbacks")
         if value is not None:
             return value
         else:
@@ -623,7 +623,7 @@ class Registry:
         Deactivate this registry.
         """
         if self is not None and self != Registry._active_global_registry:
-            _LOGGER.warning(f"attempted to deactivate registry that is inactive")
+            _LOGGER.warning("attempted to deactivate registry that is inactive")
         Registry._active_global_registry = None
 
     ##################################################

--- a/src/talondoc/analysis/registry/__init__.py
+++ b/src/talondoc/analysis/registry/__init__.py
@@ -144,7 +144,6 @@ class Registry:
                     yield self.get(data.Package, package)
                 except UnknownReference as e:
                     _LOGGER.warning(f"resolve_packages: {e}")
-                    pass
 
     def resolve_files(
         self, files: Iterator[data.FileName | data.File]
@@ -157,7 +156,6 @@ class Registry:
                     yield self.get(data.File, file)
                 except UnknownReference as e:
                     _LOGGER.warning(f"resolve_files: {e}")
-                    pass
 
     def resolve_contexts(
         self, contexts: Iterator[data.FileName | data.File | data.Context]

--- a/src/talondoc/analysis/registry/__init__.py
+++ b/src/talondoc/analysis/registry/__init__.py
@@ -69,8 +69,7 @@ class Registry:
             if self._continue_on_error:
                 _LOGGER.warning(exc)
                 return old_value
-            else:
-                raise exc
+            raise exc
         store[value.name] = value
         # Set the active package, file, module, or context.
         if isinstance(value, data.Package):
@@ -277,13 +276,12 @@ class Registry:
             raise NotImplementedError("Registry.get does not support callbacks")
         if value is not None:
             return value
-        else:
-            raise UnknownReference(
-                cls,
-                name,
-                referenced_by=referenced_by,
-                known_references=tuple(self._typed_store(cls).keys()),
-            )
+        raise UnknownReference(
+            cls,
+            name,
+            referenced_by=referenced_by,
+            known_references=tuple(self._typed_store(cls).keys()),
+        )
 
     @overload
     def lookup(
@@ -324,8 +322,7 @@ class Registry:
                     init_args[name] = init_args.get(name) or getattr(datum, name)
         if init_args:
             return cls(**init_args)
-        else:
-            return None
+        return None
 
     def lookup_description(self, cls: type[Data], name: Any) -> str | None:
         if issubclass(cls, SimpleData):
@@ -351,12 +348,10 @@ class Registry:
             def _complexity(obj: GroupDataVar) -> int:
                 if issubclass(obj.parent_type, data.Module):
                     return _IS_DECLARATION
-                else:
-                    ctx = self.lookup(data.Context, obj.parent_name)
-                    if ctx is None:
-                        return _IS_ALWAYS_ON
-                    else:
-                        return _IS_ALWAYS_ON + len(ctx.matches)
+                ctx = self.lookup(data.Context, obj.parent_name)
+                if ctx is None:
+                    return _IS_ALWAYS_ON
+                return _IS_ALWAYS_ON + len(ctx.matches)
 
             # Sort all objects in the group by the complexity of their matches:
             sorted_group = [(_complexity(obj), obj) for obj in group]

--- a/src/talondoc/analysis/registry/data/__init__.py
+++ b/src/talondoc/analysis/registry/data/__init__.py
@@ -147,8 +147,7 @@ field_script = parse_field("script", parse_script)
 def asdict_list_value(value: ListValue) -> JsonValue:
     if isinstance(value, Mapping):
         return {key: asdict_pickle(val) for key, val in value.items()}
-    else:
-        return list(value)
+    return list(value)
 
 
 def parse_list_value(

--- a/src/talondoc/analysis/registry/data/__init__.py
+++ b/src/talondoc/analysis/registry/data/__init__.py
@@ -3,13 +3,13 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import partial
 from inspect import Signature
-from typing import Any, Optional, Union
+from typing import Any, Literal, TypeAlias
 
 import tree_sitter_talon
 from tree_sitter_talon import Node as Node
 from tree_sitter_talon import Point as Point
 from tree_sitter_talon import TalonBlock, TalonMatch, TalonRule
-from typing_extensions import Literal, TypeAlias, TypeVar, final
+from typing_extensions import TypeVar, final
 
 from ...._util.logging import getLogger
 from .abc import (
@@ -59,9 +59,9 @@ SettingName: TypeAlias = str
 ModeName: TypeAlias = str
 TagName: TypeAlias = str
 
-EventCode: TypeAlias = Union[int, str]
+EventCode: TypeAlias = int | str
 Script: TypeAlias = TalonBlock
-ListValue: TypeAlias = Union[dict[str, Any], list[str]]
+ListValue: TypeAlias = dict[str, Any] | list[str]
 SettingValue: TypeAlias = Any
 Match: TypeAlias = TalonMatch
 Rule: TypeAlias = TalonRule
@@ -151,7 +151,11 @@ def asdict_list_value(value: ListValue) -> JsonValue:
         return list(value)
 
 
-def parse_list_value(value: JsonValue, *, context: dict[str, str] = {}) -> ListValue:
+def parse_list_value(
+    value: JsonValue, *, context: dict[str, str] | None = None
+) -> ListValue:
+    if context is None:
+        context = {}
     if isinstance(value, Mapping):
         return {
             key: parse_pickle(val, context=context)
@@ -164,7 +168,7 @@ def parse_list_value(value: JsonValue, *, context: dict[str, str] = {}) -> ListV
     )
 
 
-def field_list_value(value: JsonValue) -> Optional[ListValue]:
+def field_list_value(value: JsonValue) -> ListValue | None:
     context: dict[str, str] = {
         "object_type": "list",
         "field_name": "value",
@@ -185,7 +189,7 @@ asdict_setting_value = asdict_pickle
 parse_setting_value = parse_pickle
 
 
-def field_setting_value(value: JsonValue) -> Optional[SettingValue]:
+def field_setting_value(value: JsonValue) -> SettingValue | None:
     context: dict[str, str] = {
         "object_type": "setting",
         "field_name": "value",
@@ -248,7 +252,7 @@ class Module(SimpleData):
     index: int
 
     name: ModuleName = field(init=False, hash=False)
-    description: Optional[str]
+    description: str | None
     location: Location
     parent_name: FileName
     parent_type: type[File] = field(default=File, init=False, hash=False)
@@ -290,7 +294,7 @@ class Context(SimpleData):
     matches: list[Match]
 
     name: ContextName = field(init=False, hash=False)
-    description: Optional[str]
+    description: str | None
     location: Location
     parent_name: FileName
     parent_type: type[File] = field(default=File, init=False, hash=False)
@@ -335,8 +339,8 @@ class Context(SimpleData):
 # Common Decoders - Cont'd
 ##############################################################################
 
-field_parent_type: Callable[[JsonValue], Union[type[Module], type[Context]]] = (
-    parse_field("parent_type", parse_class(Module, Context))
+field_parent_type: Callable[[JsonValue], type[Module] | type[Context]] = parse_field(
+    "parent_type", parse_class(Module, Context)
 )
 
 
@@ -350,10 +354,10 @@ field_parent_type: Callable[[JsonValue], Union[type[Module], type[Context]]] = (
 class Function(SimpleData):
     namespace: str
     name: str = field(init=False, hash=False)
-    description: Optional[str] = field(init=False, hash=False)
+    description: str | None = field(init=False, hash=False)
     location: Location
-    parent_name: Union[ModuleName, ContextName]
-    parent_type: Union[type[Module], type[Context]]
+    parent_name: ModuleName | ContextName
+    parent_type: type[Module] | type[Context]
     serialisable: bool = field(default=False, init=False, hash=False)
 
     function: Callable[..., Any] = field(repr=False)
@@ -373,7 +377,7 @@ class Function(SimpleData):
 @dataclass(unsafe_hash=True)
 class Callback(Data):
     name: str = field(init=False, hash=False)
-    description: Optional[str] = field(init=False, hash=False)
+    description: str | None = field(init=False, hash=False)
     location: Location
     parent_name: FileName
     parent_type: type[File] = field(default=File, init=False, hash=False)
@@ -402,7 +406,7 @@ class Command(GroupData):
     script: Script
 
     name: str = field(init=False, hash=False)
-    description: Optional[str]
+    description: str | None
     location: Location
     parent_name: ContextName
     parent_type: type[Context] = field(default=Context, init=False, hash=False)
@@ -437,7 +441,7 @@ class Command(GroupData):
 ##############################################################################
 
 
-def field_action_function_signature(value: JsonValue) -> Optional[Signature]:
+def field_action_function_signature(value: JsonValue) -> Signature | None:
     context: dict[str, str] = {
         "object_type": "action",
         "field_name": "function_signature",
@@ -452,14 +456,14 @@ def field_action_function_signature(value: JsonValue) -> Optional[Signature]:
 @final
 @dataclass(unsafe_hash=True)
 class Action(GroupDataHasFunction):
-    function_name: Optional[FunctionName]
-    function_signature: Optional[Signature]
+    function_name: FunctionName | None
+    function_signature: Signature | None
 
     name: ActionName
-    description: Optional[str]
-    location: Union[Literal["builtin"], Location]
-    parent_name: Union[ModuleName, ContextName]
-    parent_type: Union[type[Module], type[Context]]
+    description: str | None
+    location: Literal["builtin"] | Location
+    parent_name: ModuleName | ContextName
+    parent_type: type[Module] | type[Context]
     serialisable: bool = field(default=True, init=False, hash=False)
 
     @classmethod
@@ -486,7 +490,7 @@ class Action(GroupDataHasFunction):
         }
 
 
-def field_capture_function_signature(value: JsonValue) -> Optional[Signature]:
+def field_capture_function_signature(value: JsonValue) -> Signature | None:
     context: dict[str, str] = {
         "object_type": "capture",
         "field_name": "default",
@@ -503,14 +507,14 @@ def field_capture_function_signature(value: JsonValue) -> Optional[Signature]:
 @dataclass(unsafe_hash=True)
 class Capture(GroupDataHasFunction):
     rule: Rule
-    function_name: Optional[FunctionName]
-    function_signature: Optional[Signature]
+    function_name: FunctionName | None
+    function_signature: Signature | None
 
     name: CaptureName
-    description: Optional[str]
-    location: Union[Literal["builtin"], Location]
-    parent_name: Union[ModuleName, ContextName]
-    parent_type: Union[type[Module], type[Context]]
+    description: str | None
+    location: Literal["builtin"] | Location
+    parent_name: ModuleName | ContextName
+    parent_type: type[Module] | type[Context]
     serialisable: bool = field(default=True, init=False, hash=False)
 
     @classmethod
@@ -542,14 +546,14 @@ class Capture(GroupDataHasFunction):
 @final
 @dataclass(unsafe_hash=True)
 class List(GroupData):
-    value: Optional[ListValue]
-    value_type_hint: Optional[type[Any]]
+    value: ListValue | None
+    value_type_hint: type[Any] | None
 
     name: ListName
-    description: Optional[str]
-    location: Union[None, Literal["builtin"], Location]
-    parent_name: Union[ModuleName, ContextName]
-    parent_type: Union[type[Module], type[Context]]
+    description: str | None
+    location: None | Literal["builtin"] | Location
+    parent_name: ModuleName | ContextName
+    parent_type: type[Module] | type[Context]
     serialisable: bool = field(default=True, init=False, hash=False)
 
     def __post_init__(self, *_args: Any, **_kwargs: Any) -> None:
@@ -560,7 +564,8 @@ class List(GroupData):
         else:
             if type(self.value).__name__ != "ObjectShim" and self.value is not None:
                 _LOGGER.warning(  # type: ignore[unreachable]
-                    f"List value for {self.name} should be list or dict, found {type(self.value)}"
+                    f"List value for {self.name} should be "
+                    f"list or dict, found {type(self.value)}"
                 )
             self.value = None
         super().__post_init__(*_args, **_kwargs)
@@ -592,14 +597,14 @@ class List(GroupData):
 @final
 @dataclass(unsafe_hash=True)
 class Setting(GroupData):
-    value: Optional[SettingValue]
-    value_type_hint: Optional[type[Any]]
+    value: SettingValue | None
+    value_type_hint: type[Any] | None
 
     name: SettingName
-    description: Optional[str]
-    location: Union[None, Literal["builtin"], Location]
-    parent_name: Union[ModuleName, ContextName]
-    parent_type: Union[type[Module], type[Context]]
+    description: str | None
+    location: None | Literal["builtin"] | Location
+    parent_name: ModuleName | ContextName
+    parent_type: type[Module] | type[Context]
     serialisable: bool = field(default=True, init=False, hash=False)
 
     @classmethod
@@ -630,8 +635,8 @@ class Setting(GroupData):
 @dataclass(unsafe_hash=True)
 class Mode(SimpleData):
     name: ModeName
-    description: Optional[str]
-    location: Union[None, Literal["builtin"], Location]
+    description: str | None
+    location: None | Literal["builtin"] | Location
     parent_name: ModuleName
     parent_type: type[Module] = field(default=Module, init=False, hash=False)
     serialisable: bool = field(default=True, init=False, hash=False)
@@ -658,8 +663,8 @@ class Mode(SimpleData):
 @dataclass(unsafe_hash=True)
 class Tag(SimpleData):
     name: TagName
-    description: Optional[str]
-    location: Union[None, Literal["builtin"], Location]
+    description: str | None
+    location: None | Literal["builtin"] | Location
     parent_name: ModuleName
     parent_type: type[Module] = field(default=Module, init=False, hash=False)
     serialisable: bool = field(default=True, init=False, hash=False)

--- a/src/talondoc/analysis/registry/data/abc.py
+++ b/src/talondoc/analysis/registry/data/abc.py
@@ -101,7 +101,7 @@ class Location:
 
     @staticmethod
     def from_function(function: Callable[..., Any]) -> "Location":
-        assert callable(function), f"Location.from_function received {repr(function)}"
+        assert callable(function), f"Location.from_function received {function!r}"
         path = Path(function.__code__.co_filename)
         return Location(path=path, start_line=function.__code__.co_firstlineno)
 
@@ -119,7 +119,7 @@ class Location:
                 end_line=parse_optfield("end_line", parse_int)(value),
                 end_column=parse_optfield("end_column", parse_int)(value),
             )
-        raise TypeError(f"Expected literal 'builtin' or Location, found {repr(value)}")
+        raise TypeError(f"Expected literal 'builtin' or Location, found {value!r}")
 
     def to_dict(self) -> JsonValue:
         return asdict(self)

--- a/src/talondoc/analysis/registry/data/abc.py
+++ b/src/talondoc/analysis/registry/data/abc.py
@@ -242,12 +242,12 @@ class DuplicateData(Exception):
     data: Sequence[Data]
 
     def __str__(self) -> str:
-        cls_names = set([data.__class__.__name__ for data in self.data])
+        cls_names = {data.__class__.__name__ for data in self.data}
         if len(cls_names) >= 2:
             _LOGGER.warning(
                 f"DuplicateData exception with types {', '.join(cls_names)}"
             )
-        data_names = set([data.name for data in self.data])
+        data_names = {data.name for data in self.data}
         if len(data_names) >= 2:
             _LOGGER.warning(
                 f"DuplicateData exception with names {', '.join(data_names)}"

--- a/src/talondoc/analysis/registry/data/abc.py
+++ b/src/talondoc/analysis/registry/data/abc.py
@@ -2,10 +2,9 @@ import re
 from abc import abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass
-from functools import singledispatch
 from inspect import Signature
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, TypeGuard, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import editdistance
 from tree_sitter_talon import Node as Node

--- a/src/talondoc/analysis/registry/data/abc.py
+++ b/src/talondoc/analysis/registry/data/abc.py
@@ -67,10 +67,8 @@ class Location:
         if line is not None:
             if column is not None:
                 return f"{line}:{column}"
-            else:
-                return f"{line}"
-        else:
-            return None
+            return f"{line}"
+        return None
 
     def __str__(self) -> str:
         resolved_path = self.path.resolve()
@@ -84,10 +82,8 @@ class Location:
             end_position = Location._str_from_point(self.end_line, self.end_column)
             if end_position is not None:
                 return f"{resolved_path}:{start_position}-{end_position}"
-            else:
-                return f"{resolved_path}:{start_position}"
-        else:
-            return f"{resolved_path}"
+            return f"{resolved_path}:{start_position}"
+        return f"{resolved_path}"
 
     @staticmethod
     def from_ast(path: Path, node: Node) -> "Location":
@@ -128,15 +124,13 @@ class Location:
 def parse_location(value: JsonValue) -> Union[Literal["builtin"], "Location"]:
     if isinstance(value, str) and value == "builtin":
         return "builtin"
-    else:
-        return Location.from_dict(parse_dict(value))
+    return Location.from_dict(parse_dict(value))
 
 
 def asdict_location(location: Union[Literal["builtin"], "Location"]) -> JsonValue:
     if isinstance(location, str) and location == "builtin":
         return "builtin"
-    else:
-        return location.to_dict()
+    return location.to_dict()
 
 
 ##############################################################################

--- a/src/talondoc/analysis/registry/data/abc.py
+++ b/src/talondoc/analysis/registry/data/abc.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from inspect import Signature
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Union
 
 import editdistance
 from tree_sitter_talon import Node as Node
@@ -24,7 +24,7 @@ from tree_sitter_talon import (
     TalonStartAnchor,
     TalonWord,
 )
-from typing_extensions import Literal, Self, TypeVar, final
+from typing_extensions import Self, TypeVar, final
 
 from ...._util.logging import getLogger
 from .serialise import (
@@ -57,13 +57,13 @@ else:
 @dataclass(unsafe_hash=True)
 class Location:
     path: Path
-    start_line: Optional[int] = None
-    start_column: Optional[int] = None
-    end_line: Optional[int] = None
-    end_column: Optional[int] = None
+    start_line: int | None = None
+    start_column: int | None = None
+    end_line: int | None = None
+    end_column: int | None = None
 
     @staticmethod
-    def _str_from_point(line: Optional[int], column: Optional[int]) -> Optional[str]:
+    def _str_from_point(line: int | None, column: int | None) -> str | None:
         if line is not None:
             if column is not None:
                 return f"{line}:{column}"
@@ -147,10 +147,10 @@ def asdict_location(location: Union[Literal["builtin"], "Location"]) -> JsonValu
 @dataclass(unsafe_hash=True)
 class Data:
     name: str
-    description: Optional[str]
+    description: str | None
     location: Union[None, Literal["builtin"], "Location"]
-    parent_name: Optional[str]
-    parent_type: Optional[Union[type[Package], type[File], type[Module], type[Context]]]
+    parent_name: str | None
+    parent_type: type[Package] | type[File] | type[Module] | type[Context] | None
     serialisable: bool
 
     @property
@@ -199,7 +199,7 @@ SimpleDataVar = TypeVar(
 @dataclass(unsafe_hash=True)
 class GroupData(Data):
     parent_name: str
-    parent_type: Union[type[Module], type[Context]]
+    parent_type: type[Module] | type[Context]
 
     @classmethod
     @abstractmethod
@@ -221,8 +221,8 @@ GroupDataVar = TypeVar(
 
 
 class GroupDataHasFunction(GroupData):
-    function_name: Optional[str]
-    function_signature: Optional[Signature]
+    function_name: str | None
+    function_signature: Signature | None
 
 
 GroupDataHasFunctionVar = TypeVar(
@@ -267,9 +267,9 @@ class UnknownReference(Exception):
     ref_type: type[Data]
     ref_name: str
 
-    location: Optional[str] = None
-    referenced_by: Optional[Data] = None
-    known_references: Optional[Sequence[str]] = None
+    location: str | None = None
+    referenced_by: Data | None = None
+    known_references: Sequence[str] | None = None
 
     def __str__(self) -> str:
         buffer = []

--- a/src/talondoc/analysis/registry/data/serialise.py
+++ b/src/talondoc/analysis/registry/data/serialise.py
@@ -89,11 +89,11 @@ def parse_pickle(value: JsonValue, *, context: dict[str, str] = {}) -> Any:
                 field_name = context.get("field_name", None)
                 field_path = context.get("field_path", None)
                 message_buffer: list[str] = []
-                message_buffer.append(f"Cannot decode")
+                message_buffer.append("Cannot decode")
                 if field_name:
                     message_buffer.append(f"field {field_name}")
                 else:
-                    message_buffer.append(f"unknown field")
+                    message_buffer.append("unknown field")
                 if field_path:
                     message_buffer.append(f"in {field_path}")
                 if object_name:
@@ -161,7 +161,7 @@ def parse_optfield(
     def _parser(value: JsonValue) -> Optional[_T]:
         try:
             return parse_field(name, parse_opt(parser))(value)
-        except KeyError as e:
+        except KeyError:
             return None
 
     return _parser

--- a/src/talondoc/analysis/registry/data/serialise.py
+++ b/src/talondoc/analysis/registry/data/serialise.py
@@ -4,9 +4,9 @@ from collections.abc import Callable, Mapping, Sequence
 from functools import partial
 from inspect import Parameter, Signature
 from logging import WARNING
-from typing import Any, Optional, Union
+from typing import Any, TypeAlias
 
-from typing_extensions import TypeAlias, TypeVar
+from typing_extensions import TypeVar
 
 from ...._util.logging import getLogger
 
@@ -15,21 +15,15 @@ _LOGGER = getLogger(__name__)
 _S = TypeVar("_S")
 _T = TypeVar("_T")
 
-JsonValue: TypeAlias = Union[
-    None,
-    int,
-    str,
-    dict[str, "JsonValue"],
-    list["JsonValue"],
-]
+JsonValue: TypeAlias = None | int | str | dict[str, "JsonValue"] | list["JsonValue"]
 
 ##############################################################################
 # Decoder
 ##############################################################################
 
 
-def asdict_opt(asdict: Callable[[_S], _T]) -> Callable[[Optional[_S]], Optional[_T]]:
-    def _asdict(value: Optional[_S]) -> Optional[_T]:
+def asdict_opt(asdict: Callable[[_S], _T]) -> Callable[[_S | None], _T | None]:
+    def _asdict(value: _S | None) -> _T | None:
         if value is None:
             return None
         else:
@@ -75,7 +69,9 @@ def asdict_signature(sig: Signature) -> JsonValue:
 ##############################################################################
 
 
-def parse_pickle(value: JsonValue, *, context: dict[str, str] = {}) -> Any:
+def parse_pickle(value: JsonValue, *, context: dict[str, str] | None = None) -> Any:
+    if context is None:
+        context = {}
     if isinstance(value, str):
         return parse_str(value)
     elif isinstance(value, Mapping):
@@ -84,10 +80,10 @@ def parse_pickle(value: JsonValue, *, context: dict[str, str] = {}) -> Any:
             return pickle.loads(base64.b64decode(value, validate=True))
         except ModuleNotFoundError as e:
             if _LOGGER.isEnabledFor(WARNING):
-                object_name = context.get("object_name", None)
+                object_name = context.get("object_name")
                 object_type = context.get("object_type", "object")
-                field_name = context.get("field_name", None)
-                field_path = context.get("field_path", None)
+                field_name = context.get("field_name")
+                field_path = context.get("field_path")
                 message_buffer: list[str] = []
                 message_buffer.append("Cannot decode")
                 if field_name:
@@ -126,8 +122,8 @@ def parse_list_of(parser: Callable[[JsonValue], _T]) -> Callable[[JsonValue], li
     return lambda value: list(map(parser, parse_list(value)))
 
 
-def parse_opt(parser: Callable[[JsonValue], _T]) -> Callable[[JsonValue], Optional[_T]]:
-    def _parser(value: JsonValue) -> Optional[_T]:
+def parse_opt(parser: Callable[[JsonValue], _T]) -> Callable[[JsonValue], _T | None]:
+    def _parser(value: JsonValue) -> _T | None:
         if value is None:
             return None
         else:
@@ -150,15 +146,15 @@ def parse_field(
         try:
             return parser(value[name])
         except TypeError as e:
-            raise TypeError(f"Error when checking type for field {name}. {e}")
+            raise TypeError(f"Error when checking type for field {name}. {e}") from e
 
     return _parser
 
 
 def parse_optfield(
     name: str, parser: Callable[[JsonValue], _T]
-) -> Callable[[JsonValue], Optional[_T]]:
-    def _parser(value: JsonValue) -> Optional[_T]:
+) -> Callable[[JsonValue], _T | None]:
+    def _parser(value: JsonValue) -> _T | None:
         try:
             return parse_field(name, parse_opt(parser))(value)
         except KeyError:
@@ -191,7 +187,11 @@ parse_kind = parse_enum(
 )
 
 
-def parse_parameter(value: JsonValue, *, context: dict[str, str] = {}) -> Parameter:
+def parse_parameter(
+    value: JsonValue, *, context: dict[str, str] | None = None
+) -> Parameter:
+    if context is None:
+        context = {}
     return Parameter(
         name=parse_field("name", parse_str)(value),
         kind=parse_field("kind", parse_kind)(value),
@@ -203,12 +203,18 @@ def parse_parameter(value: JsonValue, *, context: dict[str, str] = {}) -> Parame
 
 
 def parse_parameters(
-    value: JsonValue, *, context: dict[str, str] = {}
+    value: JsonValue, *, context: dict[str, str] | None = None
 ) -> Sequence[Parameter]:
+    if context is None:
+        context = {}
     return tuple(map(partial(parse_parameter, context=context), parse_list(value)))
 
 
-def parse_signature(value: JsonValue, *, context: dict[str, str] = {}) -> Signature:
+def parse_signature(
+    value: JsonValue, *, context: dict[str, str] | None = None
+) -> Signature:
+    if context is None:
+        context = {}
     return Signature(
         parameters=parse_field(
             "parameters", partial(parse_parameters, context=context)

--- a/src/talondoc/analysis/registry/data/serialise.py
+++ b/src/talondoc/analysis/registry/data/serialise.py
@@ -26,8 +26,7 @@ def asdict_opt(asdict: Callable[[_S], _T]) -> Callable[[_S | None], _T | None]:
     def _asdict(value: _S | None) -> _T | None:
         if value is None:
             return None
-        else:
-            return asdict(value)
+        return asdict(value)
 
     return _asdict
 
@@ -35,9 +34,8 @@ def asdict_opt(asdict: Callable[[_S], _T]) -> Callable[[_S | None], _T | None]:
 def asdict_pickle(value: Any) -> JsonValue:
     if isinstance(value, str):
         return value
-    else:
-        value = base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
-        return {"pickle": value}
+    value = base64.b64encode(pickle.dumps(value)).decode(encoding="utf-8")
+    return {"pickle": value}
 
 
 def asdict_class(cls: type) -> JsonValue:
@@ -74,7 +72,7 @@ def parse_pickle(value: JsonValue, *, context: dict[str, str] | None = None) -> 
         context = {}
     if isinstance(value, str):
         return parse_str(value)
-    elif isinstance(value, Mapping):
+    if isinstance(value, Mapping):
         value = parse_str(value["pickle"])
         try:
             return pickle.loads(base64.b64decode(value, validate=True))
@@ -126,8 +124,7 @@ def parse_opt(parser: Callable[[JsonValue], _T]) -> Callable[[JsonValue], _T | N
     def _parser(value: JsonValue) -> _T | None:
         if value is None:
             return None
-        else:
-            return parser(value)
+        return parser(value)
 
     return _parser
 

--- a/src/talondoc/analysis/static/__init__.py
+++ b/src/talondoc/analysis/static/__init__.py
@@ -1,6 +1,5 @@
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional
 
 from ..registry import Registry
 from ..registry.data import Package
@@ -26,7 +25,7 @@ def analyse_package(
     registry: Registry,
     package_dir: Path,
     *,
-    package_name: Optional[str] = None,
+    package_name: str | None = None,
     include: Sequence[str] = (),
     exclude: Sequence[str] = (),
     trigger: Sequence[str] = (),

--- a/src/talondoc/analysis/static/python/__init__.py
+++ b/src/talondoc/analysis/static/python/__init__.py
@@ -34,8 +34,7 @@ class TalonShimFinder(MetaPathFinder):
         def load_module(cls, fullname: str) -> ModuleType:
             if fullname == "talon":
                 return TalonShim()
-            else:
-                return ModuleShim(fullname)
+            return ModuleShim(fullname)
 
     @classmethod
     def _is_module(cls, fullname: str) -> bool:
@@ -57,9 +56,8 @@ class TalonShimFinder(MetaPathFinder):
                 loader=cls.TalonShimLoader(),
                 is_package=True,
             )
-        else:
-            # Allow normal sys.path stuff to handle everything else
-            return None
+        # Allow normal sys.path stuff to handle everything else
+        return None
 
 
 @contextmanager
@@ -114,19 +112,17 @@ def talon_package_shims(package: data.Package) -> Iterator[None]:
                         submodule_search_location
                     )
                     return module_spec
-                else:
-                    path = str(cls._module_path(fullname).with_suffix(".py"))
-                    module_spec = ModuleSpec(
-                        name=fullname,
-                        loader=SourceFileLoader(fullname, path),
-                        origin=path,
-                        is_package=False,
-                    )
-                    module_spec.has_location = True
-                    return module_spec
-            else:
-                # Allow normal sys.path stuff to handle everything else
-                return None
+                path = str(cls._module_path(fullname).with_suffix(".py"))
+                module_spec = ModuleSpec(
+                    name=fullname,
+                    loader=SourceFileLoader(fullname, path),
+                    origin=path,
+                    is_package=False,
+                )
+                module_spec.has_location = True
+                return module_spec
+            # Allow normal sys.path stuff to handle everything else
+            return None
 
     sys.meta_path.insert(0, PackagePathFinder)
     try:

--- a/src/talondoc/analysis/static/python/__init__.py
+++ b/src/talondoc/analysis/static/python/__init__.py
@@ -6,7 +6,7 @@ from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec, PathFinder, SourceFileLoader
 from pathlib import Path
 from types import ModuleType
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from ...._util.logging import getLogger
 from ...._util.progress_bar import ProgressBar
@@ -48,9 +48,9 @@ class TalonShimFinder(MetaPathFinder):
     def find_spec(
         cls,
         fullname: str,
-        path: Optional[Sequence[str]] = None,
-        target: Optional[ModuleType] = None,
-    ) -> Optional[ModuleSpec]:
+        path: Sequence[str] | None = None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
         if cls._is_module(fullname):
             return ModuleSpec(
                 name=fullname,
@@ -99,9 +99,9 @@ def talon_package_shims(package: data.Package) -> Iterator[None]:
         def find_spec(
             cls,
             fullname: str,
-            path: Optional[Sequence[str]] = None,
-            target: Optional[ModuleType] = None,
-        ) -> Optional[ModuleSpec]:
+            path: Sequence[str] | None = None,
+            target: ModuleType | None = None,
+        ) -> ModuleSpec | None:
             if cls._is_module(fullname):
                 if cls._is_subpackage(fullname):
                     module_spec = ModuleSpec(
@@ -137,7 +137,7 @@ def talon_package_shims(package: data.Package) -> Iterator[None]:
 
 @contextmanager
 def talon_shims(
-    registry: Registry, *, package: Optional[data.Package] = None
+    registry: Registry, *, package: data.Package | None = None
 ) -> Iterator[None]:
     sys.meta_path.insert(0, TalonShimFinder)
     try:

--- a/src/talondoc/analysis/static/python/shims.py
+++ b/src/talondoc/analysis/static/python/shims.py
@@ -595,7 +595,7 @@ class TalonShim(ModuleShim):
             def __decorator(func: Callable[..., Any]) -> Callable[..., Any]:
                 # LINT: check if decorated function is a function
                 if not inspect.isfunction(func):
-                    _LOGGER.warning(f"Decorated object is not a function.")
+                    _LOGGER.warning("Decorated object is not a function.")
                     return func
 
                 location = Location.from_function(func)

--- a/src/talondoc/analysis/static/python/shims.py
+++ b/src/talondoc/analysis/static/python/shims.py
@@ -60,7 +60,7 @@ class ObjectShim:
     def __enter__(self) -> Any:
         return self
 
-    def __exit__(self, *_args: Any) -> None:
+    def __exit__(self, *_args: object) -> None:
         pass
 
     def __add__(self, other: Any) -> Any:

--- a/src/talondoc/analysis/static/talon.py
+++ b/src/talondoc/analysis/static/talon.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Iterator, Sequence
 
 from tree_sitter_talon import (
     ParseError,

--- a/src/talondoc/description/__init__.py
+++ b/src/talondoc/description/__init__.py
@@ -106,12 +106,11 @@ def and_then(
 ) -> Description | None:
     if desc1 is None:
         return desc2
-    elif desc2 is None:
+    if desc2 is None:
         return desc1
-    elif isinstance(desc1, Value) and isinstance(desc2, Value):
+    if isinstance(desc1, Value) and isinstance(desc2, Value):
         return Value(f"{desc1} {desc2}")
-    else:
-        return Steps(steps=(*desc1.as_steps().steps, *desc2.as_steps().steps))
+    return Steps(steps=(*desc1.as_steps().steps, *desc2.as_steps().steps))
 
 
 def concat(*desclike: DescLike) -> Description | None:

--- a/src/talondoc/description/__init__.py
+++ b/src/talondoc/description/__init__.py
@@ -18,9 +18,9 @@ class InvalidInterpolation(Exception):
     template: Optional["StepsTemplate"] = None
 
     def __str__(self) -> str:
-        msg = f"Cannot interpolate '{repr(self.argument)}'"
+        msg = f"Cannot interpolate '{self.argument!r}'"
         if self.template:
-            msg += f" into template '{repr(self.template)}'"
+            msg += f" into template '{self.template!r}'"
         return msg
 
 

--- a/src/talondoc/description/__init__.py
+++ b/src/talondoc/description/__init__.py
@@ -158,7 +158,7 @@ def from_docstring(docstring: str) -> Optional[Description]:
             desc = Value(desc=doc.returns.description)
             return desc
 
-    except docstring_parser.ParseError as e:
+    except docstring_parser.ParseError:
         pass
 
     # Treat the docstring as a series of steps:

--- a/src/talondoc/description/describer.py
+++ b/src/talondoc/description/describer.py
@@ -1,6 +1,5 @@
 from collections.abc import Callable
-from functools import singledispatchmethod
-from typing import Any, Optional, TypeVar
+from typing import Optional, TypeVar
 
 from tree_sitter_talon import (
     Node,

--- a/src/talondoc/description/describer.py
+++ b/src/talondoc/description/describer.py
@@ -52,8 +52,7 @@ class TalonScriptDescriber:
         # Try the docstring_hook:
         docstring = self.docstring_hook(cls.__name__, name)
         # Try the registry:
-        docstring = docstring or self.registry.lookup_description(cls, name)
-        return docstring
+        return docstring or self.registry.lookup_description(cls, name)
 
     def describe(self, ast: Node) -> Description | None:
         match ast:

--- a/src/talondoc/sphinx/__init__.py
+++ b/src/talondoc/sphinx/__init__.py
@@ -62,13 +62,15 @@ def _is_talon_package(talon_package: Any) -> TypeGuard[TalonPackage]:
 
 
 def _canonicalize_talon_package(talon_package: Any) -> Optional[TalonPackage]:
-    if talon_package is None:
-        return None
-    if type(talon_package) == str:
-        return {"path": talon_package}
-    if _is_talon_package(talon_package):
-        return talon_package
-    raise TypeError(type(talon_package))
+    match talon_package:
+        case str():
+            return {"path": talon_package}
+        case dict() if _is_talon_package(talon_package):
+            return talon_package
+        case None:
+            return None
+        case _:
+            raise TypeError(type(talon_package))
 
 
 def _canonicalize_talon_packages(talon_packages: Any) -> Sequence[TalonPackage]:
@@ -93,13 +95,15 @@ def _canonicalize_talon_packages(talon_packages: Any) -> Sequence[TalonPackage]:
 
 
 def _canonicalize_vararg(vararg: Union[None, str, Sequence[str]]) -> Sequence[str]:
-    if vararg is None:
-        return ()
-    if type(vararg) == str:
-        return (vararg,)
-    if isinstance(vararg, Sequence):
-        return tuple(vararg)
-    raise TypeError(type(vararg))
+    match vararg:
+        case str():
+            return (vararg,)
+        case Sequence():
+            return tuple(vararg)
+        case None:
+            return ()
+        case _:
+            raise TypeError(type(vararg))
 
 
 def _talon_packages(env: BuildEnvironment) -> Sequence[TalonPackage]:

--- a/src/talondoc/sphinx/__init__.py
+++ b/src/talondoc/sphinx/__init__.py
@@ -1,9 +1,8 @@
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, Optional, Union, cast
+from typing import Any, TypeGuard, cast
 
 from sphinx.application import BuildEnvironment, Sphinx
-from typing_extensions import TypeGuard
 
 from .._util.logging import getLogger
 from .._version import __version__
@@ -26,25 +25,25 @@ def _is_talon_package(talon_package: Any) -> TypeGuard[TalonPackage]:
     try:
         assert isinstance(talon_package, dict)
         path = talon_package.get("path", None)
-        assert isinstance(path, (str, Path))
+        assert isinstance(path, str | Path)
         name = talon_package.get("name", None)
-        assert isinstance(name, (str,))
+        assert isinstance(name, str)
         include = talon_package.get("include", None)
         assert (
             include is None
-            or isinstance(include, (str, Path))
+            or isinstance(include, str | Path)
             or (
                 isinstance(include, Sequence)
-                and all(isinstance(path, (str, Path)) for path in include)
+                and all(isinstance(path, str | Path) for path in include)
             )
         )
         exclude = talon_package.get("exclude", None)
         assert (
             exclude is None
-            or isinstance(exclude, (str, Path))
+            or isinstance(exclude, str | Path)
             or (
                 isinstance(exclude, Sequence)
-                and all(isinstance(path, (str, Path)) for path in exclude)
+                and all(isinstance(path, str | Path) for path in exclude)
             )
         )
         trigger = talon_package.get("trigger", None)
@@ -53,7 +52,7 @@ def _is_talon_package(talon_package: Any) -> TypeGuard[TalonPackage]:
             or isinstance(trigger, str)
             or (
                 isinstance(trigger, Sequence)
-                and all(isinstance(event, (str,)) for event in trigger)
+                and all(isinstance(event, str) for event in trigger)
             )
         )
         return True
@@ -61,7 +60,7 @@ def _is_talon_package(talon_package: Any) -> TypeGuard[TalonPackage]:
         return False
 
 
-def _canonicalize_talon_package(talon_package: Any) -> Optional[TalonPackage]:
+def _canonicalize_talon_package(talon_package: Any) -> TalonPackage | None:
     match talon_package:
         case str():
             return {"path": talon_package}
@@ -94,7 +93,7 @@ def _canonicalize_talon_packages(talon_packages: Any) -> Sequence[TalonPackage]:
     raise TypeError(type(talon_packages))
 
 
-def _canonicalize_vararg(vararg: Union[None, str, Sequence[str]]) -> Sequence[str]:
+def _canonicalize_vararg(vararg: None | str | Sequence[str]) -> Sequence[str]:
     match vararg:
         case str():
             return (vararg,)

--- a/src/talondoc/sphinx/_util/addnodes/__init__.py
+++ b/src/talondoc/sphinx/_util/addnodes/__init__.py
@@ -4,11 +4,9 @@ from typing import Any, TypeVar, Union
 
 from docutils import nodes
 from sphinx import addnodes
-from sphinx.locale import _
 
 from ...._util.builtin import (
     builtin_number_types,
-    builtin_string_types,
     builtin_type_names,
     builtin_types,
     is_builtin_string_type,

--- a/src/talondoc/sphinx/_util/addnodes/__init__.py
+++ b/src/talondoc/sphinx/_util/addnodes/__init__.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable, Sequence
 from inspect import Parameter, Signature
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar
 
 from docutils import nodes
 from sphinx import addnodes
@@ -23,9 +23,9 @@ _LOGGER = getLogger(__name__)
 
 NodeVar = TypeVar("NodeVar", bound=nodes.Node)
 
-AttributeValue = Union[Any, Sequence[Any]]
+AttributeValue = Any | Sequence[Any]
 
-NodeLike = Union[nodes.Node, Iterable[nodes.Node]]
+NodeLike = nodes.Node | Iterable[nodes.Node]
 
 ################################################################################
 # Functional Wrappers around Sphinx node types

--- a/src/talondoc/sphinx/_util/addnodes/__init__.py
+++ b/src/talondoc/sphinx/_util/addnodes/__init__.py
@@ -115,15 +115,13 @@ def desc_type(annotation: Any, **attributes: AttributeValue) -> addnodes.desc_ty
 def desc_literal(value: Any, **attributes: AttributeValue) -> addnodes.desc_sig_element:
     if value is None:
         return desc_sig_keyword(nodes.Text("None"), **attributes)
-    elif isinstance(value, builtin_number_types):
+    if isinstance(value, builtin_number_types):
         return desc_sig_literal_number(nodes.Text(repr(value)), **attributes)
-    elif is_builtin_string_type(value):
+    if is_builtin_string_type(value):
         if len(value) == 1:
             return desc_sig_literal_char(nodes.Text(repr(value)), **attributes)
-        else:
-            return desc_sig_literal_string(nodes.Text(repr(value)), **attributes)
-    else:
-        return desc_sig_element(nodes.Text(repr(value)), **attributes)
+        return desc_sig_literal_string(nodes.Text(repr(value)), **attributes)
+    return desc_sig_element(nodes.Text(repr(value)), **attributes)
 
 
 def desc_signature(

--- a/src/talondoc/sphinx/_util/addnodes/fragtable.py
+++ b/src/talondoc/sphinx/_util/addnodes/fragtable.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from docutils import nodes
-from sphinx.locale import _
 from sphinx.util.docutils import SphinxTranslator
 from sphinx.writers.html5 import HTML5Translator
 

--- a/src/talondoc/sphinx/_util/addnodes/rule.py
+++ b/src/talondoc/sphinx/_util/addnodes/rule.py
@@ -1,5 +1,4 @@
 from docutils import nodes
-from sphinx.locale import _
 from talonfmt import talonfmt
 
 from ...._util.logging import getLogger

--- a/src/talondoc/sphinx/_util/typing.py
+++ b/src/talondoc/sphinx/_util/typing.py
@@ -1,22 +1,22 @@
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 
 
-def optional_strlist(argument: Optional[str]) -> Sequence[str]:
+def optional_strlist(argument: str | None) -> Sequence[str]:
     if argument:
         return tuple(pattern.strip() for pattern in argument.split(","))
     else:
         return ()
 
 
-def optional_str(argument: Optional[str]) -> Optional[str]:
+def optional_str(argument: str | None) -> str | None:
     if argument:
         return argument.strip()
     else:
         return None
 
 
-def optional_int(argument: Optional[str]) -> Optional[int]:
+def optional_int(argument: str | None) -> int | None:
     if argument:
         return int(argument)
     else:

--- a/src/talondoc/sphinx/_util/typing.py
+++ b/src/talondoc/sphinx/_util/typing.py
@@ -5,22 +5,19 @@ from typing import Any
 def optional_strlist(argument: str | None) -> Sequence[str]:
     if argument:
         return tuple(pattern.strip() for pattern in argument.split(","))
-    else:
-        return ()
+    return ()
 
 
 def optional_str(argument: str | None) -> str | None:
     if argument:
         return argument.strip()
-    else:
-        return None
+    return None
 
 
 def optional_int(argument: str | None) -> int | None:
     if argument:
         return int(argument)
-    else:
-        return None
+    return None
 
 
 def flag(argument: Any) -> bool:

--- a/src/talondoc/sphinx/directives/__init__.py
+++ b/src/talondoc/sphinx/directives/__init__.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import sphinx.directives
 
@@ -15,17 +15,17 @@ class TalonDocDirective(sphinx.directives.SphinxDirective):  # type: ignore[misc
         return cast(TalonDomain, self.env.get_domain("talon"))
 
     @property
-    def docstring_hook(self) -> Callable[[str, str], Optional[str]]:
+    def docstring_hook(self) -> Callable[[str, str], str | None]:
         docstring_hook = self.env.config["talon_docstring_hook"]
         if docstring_hook is None:
 
-            def __docstring_hook(sort: str, name: str) -> Optional[str]:
+            def __docstring_hook(sort: str, name: str) -> str | None:
                 return None
 
             return __docstring_hook
         elif isinstance(docstring_hook, dict):
 
-            def __docstring_hook(sort: str, name: str) -> Optional[str]:
+            def __docstring_hook(sort: str, name: str) -> str | None:
                 value = docstring_hook.get(sort, {}).get(name, None)
                 assert value is None or isinstance(value, str)
                 return value
@@ -33,7 +33,7 @@ class TalonDocDirective(sphinx.directives.SphinxDirective):  # type: ignore[misc
             return __docstring_hook
         else:
 
-            def __docstring_hook(sort: str, name: str) -> Optional[str]:
+            def __docstring_hook(sort: str, name: str) -> str | None:
                 value = docstring_hook(sort, name)
                 assert value is None or isinstance(value, str)
                 return value
@@ -42,6 +42,7 @@ class TalonDocDirective(sphinx.directives.SphinxDirective):  # type: ignore[misc
 
 
 class TalonDocObjectDescription(
-    sphinx.directives.ObjectDescription[str], TalonDocDirective  # type: ignore[misc]
+    sphinx.directives.ObjectDescription[str],  # type: ignore[misc]
+    TalonDocDirective,
 ):
     pass

--- a/src/talondoc/sphinx/directives/__init__.py
+++ b/src/talondoc/sphinx/directives/__init__.py
@@ -17,28 +17,26 @@ class TalonDocDirective(sphinx.directives.SphinxDirective):  # type: ignore[misc
     @property
     def docstring_hook(self) -> Callable[[str, str], str | None]:
         docstring_hook = self.env.config["talon_docstring_hook"]
-        if docstring_hook is None:
 
-            def __docstring_hook(sort: str, name: str) -> str | None:
-                return None
+        match docstring_hook:
+            case None:
 
-            return __docstring_hook
-        elif isinstance(docstring_hook, dict):
+                def __docstring_hook(sort: str, name: str) -> str | None:
+                    return None
+            case dict():
 
-            def __docstring_hook(sort: str, name: str) -> str | None:
-                value = docstring_hook.get(sort, {}).get(name, None)
-                assert value is None or isinstance(value, str)
-                return value
+                def __docstring_hook(sort: str, name: str) -> str | None:
+                    value = docstring_hook.get(sort, {}).get(name, None)
+                    assert value is None or isinstance(value, str)
+                    return value
+            case _:
 
-            return __docstring_hook
-        else:
+                def __docstring_hook(sort: str, name: str) -> str | None:
+                    value = docstring_hook(sort, name)
+                    assert value is None or isinstance(value, str)
+                    return value
 
-            def __docstring_hook(sort: str, name: str) -> str | None:
-                value = docstring_hook(sort, name)
-                assert value is None or isinstance(value, str)
-                return value
-
-            return __docstring_hook
+        return __docstring_hook
 
 
 class TalonDocObjectDescription(

--- a/src/talondoc/sphinx/directives/action.py
+++ b/src/talondoc/sphinx/directives/action.py
@@ -37,12 +37,11 @@ class TalonActionDirective(TalonDocObjectDescription):
             if default.description:
                 signode += desc_content(paragraph(nodes.Text(default.description)))
             return default.name
-        else:
-            e = UnknownReference(
-                ref_type=data.Action,
-                ref_name=sig,
-                location=self.get_location(),
-                known_references=tuple(self.talon.registry.actions.keys()),
-            )
-            _LOGGER.error(f"talon:action: {e}")
-            raise ValueError(e)
+        e = UnknownReference(
+            ref_type=data.Action,
+            ref_name=sig,
+            location=self.get_location(),
+            known_references=tuple(self.talon.registry.actions.keys()),
+        )
+        _LOGGER.error(f"talon:action: {e}")
+        raise ValueError(e)

--- a/src/talondoc/sphinx/directives/capture.py
+++ b/src/talondoc/sphinx/directives/capture.py
@@ -55,12 +55,11 @@ class TalonCaptureDirective(TalonDocObjectDescription):
                 signode += desc_content(paragraph(nodes.Text(default.description)))
 
             return default.name
-        else:
-            e = UnknownReference(
-                ref_type=data.Capture,
-                ref_name=sig,
-                location=self.get_location(),
-                known_references=tuple(self.talon.registry.captures.keys()),
-            )
-            _LOGGER.error(f"talon:capture: {e}")
-            raise ValueError(e)
+        e = UnknownReference(
+            ref_type=data.Capture,
+            ref_name=sig,
+            location=self.get_location(),
+            known_references=tuple(self.talon.registry.captures.keys()),
+        )
+        _LOGGER.error(f"talon:capture: {e}")
+        raise ValueError(e)

--- a/src/talondoc/sphinx/directives/command/__init__.py
+++ b/src/talondoc/sphinx/directives/command/__init__.py
@@ -42,4 +42,4 @@ class TalonCommandDirective(TalonDocCommandDescription):
             return command.name
         except (UnknownReference, AmbiguousSignature) as e:
             _LOGGER.error(f"talon:command: {e}")
-            raise ValueError(e)
+            raise ValueError(e) from e

--- a/src/talondoc/sphinx/directives/command/abc.py
+++ b/src/talondoc/sphinx/directives/command/abc.py
@@ -158,8 +158,7 @@ class TalonDocCommandDescription(TalonDocObjectDescription):
                     comments.append(comment.removeprefix("###").strip())
         if comments:
             return nodes.Text(" ".join(comments))
-        else:
-            return None
+        return None
 
     @final
     def _try_describe_script_with_action_docstrings(
@@ -210,8 +209,7 @@ class TalonDocCommandListDescription(TalonDocCommandDescription):
             or (len(phrases) == 1 and phrases[0] == "*")
         ):
             return "*"
-        else:
-            return tuple(map(self._split_phrase, phrases))
+        return tuple(map(self._split_phrase, phrases))
 
     @property
     def exclude(self) -> Sequence[Sequence[str]]:
@@ -254,10 +252,7 @@ class TalonDocCommandListDescription(TalonDocCommandDescription):
     ) -> bool:
         if self.include == "*":
             return True
-        else:
-            return self._match_any_of(
-                rule, self.include, default=True, fullmatch=fullmatch
-            )
+        return self._match_any_of(rule, self.include, default=True, fullmatch=fullmatch)
 
     @final
     def _matches_exclude(

--- a/src/talondoc/sphinx/directives/command/abc.py
+++ b/src/talondoc/sphinx/directives/command/abc.py
@@ -1,11 +1,12 @@
 import re
-from typing import ClassVar, Iterator, Optional, Sequence, Union, cast
+from collections.abc import Iterator, Sequence
+from typing import ClassVar, Literal, cast
 
 from docutils import nodes
 from sphinx import addnodes
 from talonfmt import talonfmt
 from tree_sitter_talon import TalonComment
-from typing_extensions import Literal, final
+from typing_extensions import final
 
 from ...._util.logging import getLogger
 from ....analysis.registry import data
@@ -23,7 +24,7 @@ _LOGGER = getLogger(__name__)
 
 class TalonDocCommandDescription(TalonDocObjectDescription):
     @property
-    def contexts(self) -> Optional[Iterator[str]]:
+    def contexts(self) -> Iterator[str] | None:
         result = [*self.options.get("context", []), *self.options.get("contexts", [])]
         return iter(result) if result else None
 
@@ -37,7 +38,7 @@ class TalonDocCommandDescription(TalonDocObjectDescription):
         text: str,
         *,
         fullmatch: bool = False,
-        restrict_to: Optional[Iterator[str]] = None,
+        restrict_to: Iterator[str] | None = None,
     ) -> data.Command:
         commands = list(
             self.find_commands(text, fullmatch=fullmatch, restrict_to=restrict_to)
@@ -61,7 +62,7 @@ class TalonDocCommandDescription(TalonDocObjectDescription):
     def get_commands(
         self,
         *,
-        restrict_to: Optional[Iterator[str]] = None,
+        restrict_to: Iterator[str] | None = None,
     ) -> Iterator[data.Command]:
         yield from self.talon.registry.get_commands(restrict_to=restrict_to)
 
@@ -71,7 +72,7 @@ class TalonDocCommandDescription(TalonDocObjectDescription):
         text: str,
         *,
         fullmatch: bool = False,
-        restrict_to: Optional[Iterator[str]] = None,
+        restrict_to: Iterator[str] | None = None,
     ) -> Iterator[data.Command]:
         _LOGGER.debug(
             f"searching for commands matching '{text}' (restricted by {restrict_to})"
@@ -95,7 +96,7 @@ class TalonDocCommandDescription(TalonDocObjectDescription):
         signode: addnodes.desc_signature,
         *,
         always_include_script: bool,
-        docstring_hook: Optional[TalonDocstringHook_Callable],
+        docstring_hook: TalonDocstringHook_Callable | None,
     ) -> addnodes.desc_signature:
         signode += desc_name(desc_rule(command.rule))
         signode += desc_content(
@@ -113,7 +114,7 @@ class TalonDocCommandDescription(TalonDocObjectDescription):
         command: data.Command,
         *,
         always_include_script: bool,
-        docstring_hook: Optional[TalonDocstringHook_Callable],
+        docstring_hook: TalonDocstringHook_Callable | None,
     ) -> Sequence[nodes.Element]:
         """
         Describe the script using the docstrings on the script, the docstrings on
@@ -121,7 +122,8 @@ class TalonDocCommandDescription(TalonDocObjectDescription):
         """
         buffer: list[nodes.Element] = []
 
-        # 1. Use the Talon docstrings in the command script. Talon docstrings are comments which start with ###.
+        # 1. Use the Talon docstrings in the command script.
+        #   Talon docstrings are comments which start with ###.
         desc = self._try_describe_script_with_script_docstrings(command)
 
         # 2. Use the Python docstrings from the actions used in the command script.
@@ -144,7 +146,7 @@ class TalonDocCommandDescription(TalonDocObjectDescription):
     def _try_describe_script_with_script_docstrings(
         self,
         command: data.Command,
-    ) -> Optional[nodes.Text]:
+    ) -> nodes.Text | None:
         """
         Describe the script using the docstrings present in the script itself.
         """
@@ -164,8 +166,8 @@ class TalonDocCommandDescription(TalonDocObjectDescription):
         self,
         command: data.Command,
         *,
-        docstring_hook: Optional[TalonDocstringHook_Callable],
-    ) -> Optional[nodes.Text]:
+        docstring_hook: TalonDocstringHook_Callable | None,
+    ) -> nodes.Text | None:
         """
         Describe the script using the docstrings on the actions used by the script.
         """
@@ -200,10 +202,8 @@ class TalonDocCommandListDescription(TalonDocCommandDescription):
         return cast(str, self.options.get("caption", None) or ".".join(self.arguments))
 
     @property
-    def include(self) -> Union[Literal["*"], Sequence[Sequence[str]]]:
-        phrases = cast(
-            Union[Literal["*"], Sequence[str]], self.options.get("include", "*")
-        )
+    def include(self) -> Literal["*"] | Sequence[Sequence[str]]:
+        phrases = cast(Literal["*"] | Sequence[str], self.options.get("include", "*"))
         if (
             phrases == "*"
             or len(phrases) == 0

--- a/src/talondoc/sphinx/directives/command/table.py
+++ b/src/talondoc/sphinx/directives/command/table.py
@@ -10,7 +10,6 @@ from ..._util.addnodes import (
     entry,
     fragtable,
     row,
-    table,
     tbody,
     tgroup,
     title,

--- a/src/talondoc/sphinx/directives/errors.py
+++ b/src/talondoc/sphinx/directives/errors.py
@@ -17,6 +17,6 @@ class AmbiguousSignature(Exception):
             [
                 f"{self.location}:"
                 f"Multiple matches found for signature '{self.signature}'",
-                *map(lambda dsc: f"- {dsc}", self.candidates),
+                *(f"- {dsc}" for dsc in self.candidates),
             ]
         )

--- a/src/talondoc/sphinx/directives/errors.py
+++ b/src/talondoc/sphinx/directives/errors.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Sequence
 
 
 @dataclass

--- a/src/talondoc/sphinx/directives/list.py
+++ b/src/talondoc/sphinx/directives/list.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 from docutils import nodes
 from sphinx import addnodes

--- a/src/talondoc/sphinx/directives/list.py
+++ b/src/talondoc/sphinx/directives/list.py
@@ -20,11 +20,9 @@ from .._util.addnodes import (
     fragtable,
     paragraph,
     row,
-    table,
     tbody,
     tgroup,
 )
-from .._util.typing import optional_int
 from . import TalonDocObjectDescription
 
 _LOGGER = getLogger(__name__)

--- a/src/talondoc/sphinx/directives/list.py
+++ b/src/talondoc/sphinx/directives/list.py
@@ -94,12 +94,11 @@ class TalonListDirective(TalonDocObjectDescription):
             signode += desc_content(*content)
 
             return default.name
-        else:
-            e = UnknownReference(
-                ref_type=data.List,
-                ref_name=sig,
-                location=self.get_location(),
-                known_references=tuple(self.talon.registry.lists.keys()),
-            )
-            _LOGGER.error(f"talon:list: {e}")
-            raise ValueError(e)
+        e = UnknownReference(
+            ref_type=data.List,
+            ref_name=sig,
+            location=self.get_location(),
+            known_references=tuple(self.talon.registry.lists.keys()),
+        )
+        _LOGGER.error(f"talon:list: {e}")
+        raise ValueError(e)

--- a/src/talondoc/sphinx/directives/mode.py
+++ b/src/talondoc/sphinx/directives/mode.py
@@ -30,12 +30,11 @@ class TalonModeDirective(TalonDocObjectDescription):
             if mode.description:
                 signode += desc_content(paragraph(nodes.Text(mode.description)))
             return mode.name
-        else:
-            e = UnknownReference(
-                ref_type=data.Mode,
-                ref_name=sig,
-                location=self.get_location(),
-                known_references=tuple(self.talon.registry.modes.keys()),
-            )
-            _LOGGER.error(f"talon:mode: {e}")
-            raise ValueError(e)
+        e = UnknownReference(
+            ref_type=data.Mode,
+            ref_name=sig,
+            location=self.get_location(),
+            known_references=tuple(self.talon.registry.modes.keys()),
+        )
+        _LOGGER.error(f"talon:mode: {e}")
+        raise ValueError(e)

--- a/src/talondoc/sphinx/directives/mode.py
+++ b/src/talondoc/sphinx/directives/mode.py
@@ -5,7 +5,7 @@ from typing_extensions import override
 from ..._util.logging import getLogger
 from ...analysis.registry import data
 from ...analysis.registry.data.abc import UnknownReference
-from .._util.addnodes import desc_content, desc_name, desc_qualname, paragraph
+from .._util.addnodes import desc_content, desc_qualname, paragraph
 from . import TalonDocObjectDescription
 
 _LOGGER = getLogger(__name__)

--- a/src/talondoc/sphinx/directives/setting.py
+++ b/src/talondoc/sphinx/directives/setting.py
@@ -1,4 +1,3 @@
-
 from docutils import nodes
 from sphinx import addnodes
 from typing_extensions import override

--- a/src/talondoc/sphinx/directives/setting.py
+++ b/src/talondoc/sphinx/directives/setting.py
@@ -59,12 +59,11 @@ class TalonSettingDirective(TalonDocObjectDescription):
                 signode += desc_content(paragraph(nodes.Text(default.description)))
 
             return default.name
-        else:
-            e = UnknownReference(
-                ref_type=data.Setting,
-                ref_name=sig,
-                location=self.get_location(),
-                known_references=tuple(self.talon.registry.settings.keys()),
-            )
-            _LOGGER.error(f"talon:setting: {e}")
-            raise ValueError(e)
+        e = UnknownReference(
+            ref_type=data.Setting,
+            ref_name=sig,
+            location=self.get_location(),
+            known_references=tuple(self.talon.registry.settings.keys()),
+        )
+        _LOGGER.error(f"talon:setting: {e}")
+        raise ValueError(e)

--- a/src/talondoc/sphinx/directives/setting.py
+++ b/src/talondoc/sphinx/directives/setting.py
@@ -1,8 +1,7 @@
-import inspect
 
 from docutils import nodes
 from sphinx import addnodes
-from typing_extensions import final, override
+from typing_extensions import override
 
 from ..._util.logging import getLogger
 from ...analysis.registry import data
@@ -10,12 +9,7 @@ from ...analysis.registry.data.abc import UnknownReference
 from .._util.addnodes import (
     desc_content,
     desc_literal,
-    desc_name,
     desc_qualname,
-    desc_sig_element,
-    desc_sig_literal_char,
-    desc_sig_literal_number,
-    desc_sig_literal_string,
     desc_sig_punctuation,
     desc_sig_space,
     desc_type,

--- a/src/talondoc/sphinx/directives/tag.py
+++ b/src/talondoc/sphinx/directives/tag.py
@@ -31,12 +31,11 @@ class TalonTagDirective(TalonDocObjectDescription):
             if tag.description:
                 signode += desc_content(paragraph(nodes.Text(tag.description)))
             return tag.name
-        else:
-            e = UnknownReference(
-                ref_type=data.Tag,
-                ref_name=sig,
-                location=self.get_location(),
-                known_references=tuple(self.talon.registry.tags.keys()),
-            )
-            _LOGGER.error(f"talon:tag: {e}")
-            raise ValueError(e)
+        e = UnknownReference(
+            ref_type=data.Tag,
+            ref_name=sig,
+            location=self.get_location(),
+            known_references=tuple(self.talon.registry.tags.keys()),
+        )
+        _LOGGER.error(f"talon:tag: {e}")
+        raise ValueError(e)

--- a/src/talondoc/sphinx/directives/tag.py
+++ b/src/talondoc/sphinx/directives/tag.py
@@ -6,7 +6,7 @@ from talondoc.analysis.registry.data.abc import UnknownReference
 
 from ..._util.logging import getLogger
 from ...analysis.registry import data
-from .._util.addnodes import desc_content, desc_name, desc_qualname, paragraph
+from .._util.addnodes import desc_content, desc_qualname, paragraph
 from . import TalonDocObjectDescription
 
 _LOGGER = getLogger(__name__)

--- a/src/talondoc/sphinx/domains.py
+++ b/src/talondoc/sphinx/domains.py
@@ -6,7 +6,6 @@ from ..analysis.registry import Registry
 from .directives.action import TalonActionDirective
 from .directives.capture import TalonCaptureDirective
 from .directives.command import TalonCommandDirective
-from .directives.command.hlist import TalonCommandHListDirective
 from .directives.command.table import TalonCommandTableDirective
 from .directives.list import TalonListDirective
 from .directives.mode import TalonModeDirective

--- a/src/talondoc/sphinx/domains.py
+++ b/src/talondoc/sphinx/domains.py
@@ -14,6 +14,8 @@ from .directives.tag import TalonTagDirective
 
 _LOGGER = getLogger(__name__)
 
+__talonDirectiveClasses__ = TalonActionDirective | TalonCaptureDirective
+
 
 class TalonDomain(Domain):  # type: ignore[misc]
     """Talon language domain."""
@@ -21,7 +23,7 @@ class TalonDomain(Domain):  # type: ignore[misc]
     name = "talon"
     label = "Talon"
 
-    directives = {
+    directives = {  # noqa: RUF012 (wants this to be a class var)
         "action": TalonActionDirective,
         "capture": TalonCaptureDirective,
         "command": TalonCommandDirective,

--- a/src/talondoc/sphinx/typing.py
+++ b/src/talondoc/sphinx/typing.py
@@ -1,26 +1,21 @@
 from collections.abc import Callable, Sequence
-from typing import Optional, Union
+from typing import TypeAlias
 
-from typing_extensions import NotRequired, Required, TypeAlias, TypedDict
+from typing_extensions import NotRequired, Required, TypedDict
 
 TalonEvent = str
 
-TalonPackage = TypedDict(
-    "TalonPackage",
-    {
-        "path": Required[str],
-        "name": NotRequired[str],
-        "include": NotRequired[Union[str, Sequence[str]]],
-        "exclude": NotRequired[Union[str, Sequence[str]]],
-        "trigger": NotRequired[Union[TalonEvent, Sequence[TalonEvent]]],
-    },
-)
 
-TalonDocstringHook_Callable: TypeAlias = Callable[[str, str], Optional[str]]
+class TalonPackage(TypedDict):
+    path: Required[str]
+    name: NotRequired[str]
+    include: NotRequired[str | Sequence[str]]
+    exclude: NotRequired[str | Sequence[str]]
+    trigger: NotRequired[TalonEvent | Sequence[TalonEvent]]
+
+
+TalonDocstringHook_Callable: TypeAlias = Callable[[str, str], str | None]
 TalonDocstringHook_Dict: TypeAlias = dict[str, dict[str, str]]
 
 
-TalonDocstringHook: TypeAlias = Union[
-    TalonDocstringHook_Callable,
-    TalonDocstringHook_Dict,
-]
+TalonDocstringHook: TypeAlias = TalonDocstringHook_Callable | TalonDocstringHook_Dict


### PR DESCRIPTION
This pull request switches the linter and formatter over to use ruff (https://docs.astral.sh/ruff/). It also adds them to the pre-commit hooks. I added the linting rules in stages in case you would like any changes to the config. Currently it uses the base recommended starting point rules and then a few additional ones on top. All but one of the ignored rule set is want they recommend is disabled if you are also using ruff to format. The other rule is from the flake8-pathlib to not get upset if `open()` is used instead of `Path.open()`. 

- [pycodestyle (E)](https://docs.astral.sh/ruff/rules/#pycodestyle-e-w)
  - Enabled the errors set of rules
- [pyflakes (F)](https://docs.astral.sh/ruff/rules/#pyflakes-f)
  - some basic linting rules 
- [pyupgrade (UP)](https://docs.astral.sh/ruff/rules/#pyupgrade-up)
  - This is a tool that automatically upgrades syntax to newer versions. This rule caused a lof of changes as it updated the typeing to use the more concise modern syntax.
- [flake8-bugbear (B)](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b)
  - Prevents some common bugs 
- [flake8-simplify(SIM)](https://docs.astral.sh/ruff/rules/#flake8-simplify-sim)
  - https://pypi.org/project/flake8_simplify/
- [isort (I)](https://docs.astral.sh/ruff/rules/#isort-i)
- [flake8-use-pathlib (PTH)](https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth)
  - Uses Pathlib utilities where possible instead of os 
- [flake8-comprehensions (C4)](https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4)
  - removes unnecessary convertions and rewrites some stuff to use comprehensions 
- [flake8-pie (PIE)](https://docs.astral.sh/ruff/rules/#flake8-pie-pie)
  - https://pypi.org/project/flake8-pie/
- [flake8-pyi (PYI)](https://docs.astral.sh/ruff/rules/#flake8-pyi-pyi)
  - Has some rules about typing
- [Ruff Specific Rules (RUFF)](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf)
- [flake8-return (RET)](https://docs.astral.sh/ruff/rules/#flake8-return-ret)
  - This one simplifies control flow when possible due to returning early. It reduces the amount of indentation needed for nested if statements amoung other things.


```toml
select = [
  # Recommended Initial
  "E",   # pycodestyle
  "F",   # Pyflakes
  "UP",  # pyupgrade
  "B",   # flake8-bugbear
  "SIM", # flake8-simplify
  "I",   # isort

  # Additional
  "PTH", # flake8-use-pathlib
  "C4",  # flake8-comprehensions (C4)
  "PIE", # flake8-pie (PIE)
  "PYI", # flake8-pyi (PYI)
  "RUF", # Ruff Specific Rules
  "RET", # flake8-return (RET)
]
```

The formatter is mostly set to the default values, though I did copy over the equivalent values from the current config. 
```toml
[tool.ruff]
line-length = 88
exclude = [".venv", ".tox", "example/community/*"]

[tool.ruff.format]
docstring-code-format = true
docstring-code-line-length = 45
```