### PR TITLE
Swap html theme from sphinx_rtd_theme to furo

### DIFF
--- a/example/docs/conf.py
+++ b/example/docs/conf.py
@@ -78,11 +78,18 @@ talon_package = {
 #     return None
 #
 
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "sphinx_rtd_theme"
+# html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 html_static_path = ["_static"]
+
+# -- Options HTML Theme Furo -------------------------------------------------
+html_theme_options = {
+    "navigation_with_keys": True,
+}
 
 
 def setup(app: Sphinx) -> None:

--- a/example/docs/index.md
+++ b/example/docs/index.md
@@ -3,7 +3,7 @@
 :::{toctree}
 :maxdepth: 1
 
-knausj_talon/index
+community/index
 :::
 
 ## Loading a Talon package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,10 @@ mypy = [
 test = [
   "bumpver",
   "myst_parser >=1,<5",
-  "sphinx_rtd_theme >=1.2,<4",
+  "furo==2024.8.6",
   "sphinx_tabs >=3.4,<5",
 ]
-docs = [
-  "myst_parser >=1,<5",
-  "sphinx_rtd_theme >=1.2,<4",
-  "sphinx_tabs >=3.4,<5",
-]
+docs = ["myst_parser >=1,<5", "furo==2024.8.6", "sphinx_tabs >=3.4,<5"]
 dev = ["ruff>=0.9,<1"]
 
 [project.scripts]


### PR DESCRIPTION
This pull request swaps out sphinx_rtd_theme for the furo theme. It is a cleaner more moder theme that was made originally for pip but is now used by a bunch of projects including cloud-init, attrs, and many others. A few benefits over sphinx_rtd_theme are that it supports a togglable dark mode and it has a secondary sidbar that has the pages toc on it for easier navigation. It also has good support mobile.


- Git Repo: https://github.com/pradyunsg/furo
- Docs: https://pradyunsg.me/furo/quickstart/

Example uses in the wild:
- https://pip.pypa.io/en/stable/
- https://www.attrs.org/en/stable/
- https://cloudinit.readthedocs.io/en/latest/